### PR TITLE
 Bug fix and added probing functionality for the method list_events()

### DIFF
--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -328,17 +328,24 @@ cdef class CyPAPI_EventSet:
             values[i] = vals[i]
         PyMem_Free(vals)
 
-    def list_events(self):
+    def list_events(self, probe = False):
         cdef int num_events = self.num_events()
-        cdef int *evts = <int *> PyMem_Malloc(num_events * sizeof(int))
-        if not evts:
-            raise Exception('Failed to allocate array')
-        cdef int number = 0
-        cdef int papi_errno = PAPI_list_events(self.event_set, evts, &number)
-        if papi_errno != PAPI_OK:
-            raise Exception(f'PAPI Error {papi_errno}: PAPI_list_events failed.')
-        result = [evts[i] for i in range(num_events)]
-        PyMem_Free(evts)
+        cdef int *evts, papi_errno
+        # does not probe EventSet
+        if not probe:
+            evts = <int *> PyMem_Malloc(num_events * sizeof(int))
+            if not evts:
+                raise Exception('Failed to allocate array')
+
+            papi_errno = PAPI_list_events( self.event_set, evts, &num_events  )
+            if papi_errno != PAPI_OK:
+                raise Exception(f'PAPI Error {papi_errno}: PAPI_list_events failed.')
+
+            result = [evts[i] for i in range(num_events)]
+            PyMem_Free(evts)
+        # probe EventSet
+        else:
+            result = num_events
         return result
 
     def state(self):


### PR DESCRIPTION
This PR addresses a bug fix for the method `.list_events()` within the `CyPAPI_EventSet` class. As well as adds the functionality of probing an EventSet, which would make it inline with `PAPI_list_events(...)`

## Bug Fix:

Previously, `.list_events()` had the following two lines of code:
```
cdef int number = 0
cdef int papi_errno = PAPI_list_events( self.event_set, evts, &number )
```
The passing of 0 to the third argument of `PAPI_list_events( int *EventSet, int *Events, int *number )` would always result in the case of probing the EventSet. Meaning that from the cyPAPI side a user would never actually get the proper EventCodes returned to them. Instead a list of values would be returned that had no correlation to any Event that would be available on a system. To remedy this, instead of having the `number` argument hard coded to be 0. I updated the code to now on the backend collect the proper number of events (`num_events`) in the current EventSet object created by the user. Which then could be passed to the `number` argument in `PAPI_list_events(...)` which would result in getting the correct events back in list format. Below will be the updated two lines of code to correct this bug:
```
cdef int num_events = self.num_events()
papi_errno = PAPI_list_events( self.event_set, evts, &num_events  )
```

## Addition of Probing Functionality
For `papi_list_events( int *EventSet, int *Events, int *number  )`, if a user provided the argument `number` with the value of 0, then it would probe the EventSet and return the current number of Events within the EventSet.

To add this functionality to cyPAPI, I have added an optional argument titled `probe` which by default is set to `False` (`probe = False`). The two cases are:

1. True, returns the number of events in the current `CyPAPI_EventSet` object
2. False, returns a list of EventCodes in the current `CyPAPI_EventSet` object for x number of events in the EventSet. E.g. `[-2147483598, -2147483546]` for PAPI_TOT_INS and PAPI_FP_OPS respectively.

The reasoning behind choosing this to be an optional argument is that an error will not occur when simply calling `.list_events()` if the argument is not provided. As an example, if a user performed the following steps:

- Created an EventSet
- Added events to the created EventSet
- Performed computations
- Called `.cleanup()` to remove all events from an EventSet

Due to the optional argument, a user could call `.list_events()` on the EventSet to make sure it is indeed empty, which in this case a empty list would output to the user ([]). If the argument `probe` was not optional then this would result in an error. 