### PR TITLE
Adding PAPI_query_event and PAPI_query_named_event into cyPAPI

### DIFF
--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -299,6 +299,20 @@ cdef class CyPAPI_enum_component_events:
     def __next__(self):
         return self.next_event()
 
+def cyPAPI_query_event(event_code):
+    cdef int papi_errno, evt_code = np.array(event_code).astype(np.intc)
+    papi_errno = PAPI_query_event(evt_code)
+
+    return papi_errno
+
+def cyPAPI_query_named_event(event_name):
+    cdef int papi_errno
+    cdef bytes evt_name = event_name.encode('utf8')
+    
+    papi_errno = PAPI_query_named_event(evt_name)
+
+    return papi_errno
+
 def cyPAPI_num_cmp_hwctrs(int cidx):
     return PAPI_num_cmp_hwctrs(cidx)
 

--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -308,7 +308,6 @@ def cyPAPI_query_event(event_code):
 def cyPAPI_query_named_event(event_name):
     cdef int papi_errno
     cdef bytes evt_name = event_name.encode('utf8')
-    
     papi_errno = PAPI_query_named_event(evt_name)
 
     return papi_errno

--- a/cypapi/papih.pxd
+++ b/cypapi/papih.pxd
@@ -122,3 +122,5 @@ cdef extern from 'papi.h':
     int PAPI_state(int EventSet, int *status)
     int PAPI_write(int EventSet, long long * values)
     int PAPI_get_eventset_component(int EventSet)
+    int PAPI_query_event(int EventCode)
+    int PAPI_query_named_event(const char *EventName)


### PR DESCRIPTION
This pull request addresses adding `PAPI_query_event( ... )` and `PAPI_query_named_event( ... )` into cyPAPI with the naming scheme `cyPAPI_query_event( ... )` and `cyPAPI_query_named_event( ... )` respectively. 

# Examples - Preset Events
Example of `cyPAPI_query_event( ... )` with `PAPI_FP_OPS`:
```python
from cypapi import *

# initialize cyPAPI
cyPAPI_library_init()

# check to see if cyPAPI has been intialized
if cyPAPI_is_initialized() != 1:
    raise Exception("cyPAPI was not successfully initialized.")

# using PAPI_FP_OPS
evt_code = -2147483546

# see if event can be counted on this architecture
if cyPAPI_query_event(evt_code) == 0:
    print(f"Event {cyPAPI_event_code_to_name(evt_code)} can be counted.")
```
Output:
```
Event PAPI_FP_OPS can be counted.
```
Example of `cyPAPI_query_named_event( ... )` with `PAPI_FP_OPS`:
```python
from cypapi import *

# initialize cyPAPI
cyPAPI_library_init()

# check to see if cyPAPI has been intialized
if cyPAPI_is_initialized() != 1:
    raise Exception("cyPAPI was not successfully initialized.")

# using PAPI_FP_OPS
evt_name = "PAPI_FP_OPS"

# see if event can be counted on this architecture
if cyPAPI_query_named_event(evt_name) == 0:
    print(f"Event {evt_name} can be counted.")
```
Output:
```
Event PAPI_FP_OPS can be counted.
```

# Examples - Native Events
Example of `cyPAPI_query_event( ... )` with a native event from perf_event:
```python
from cypapi import *

# initialize cyPAPI
cyPAPI_library_init()

# check to see if cyPAPI has been intialized
if cyPAPI_is_initialized() != 1:
    raise Exception("cyPAPI was not successfully initialized.")

# using perf_event native event
enum_cmp = CyPAPI_enum_component_events(0)
evt_code = enum_cmp.next_event()

# see if event can be counted on this architecture
if cyPAPI_query_event(evt_code) == 0:
    print(f"Event {cyPAPI_event_code_to_name(evt_code)} can be counted.")
```
Output:
```
Event perf::PERF_COUNT_HW_CPU_CYCLES can be counted.
```
Example of `cyPAPI_query_named_event( ... )` with a native event from perf_event:
```python
from cypapi import *

# initialize cyPAPI
cyPAPI_library_init()

# check to see if cyPAPI has been intialized
if cyPAPI_is_initialized() != 1:
    raise Exception("cyPAPI was not successfully initialized.")

# using perf_event native event
evt_name = "perf::PERF_COUNT_HW_CPU_CYCLES" 

# see if event can be counted on this architecture
if cyPAPI_query_named_event(evt_name) == 0:
    print(f"Event {evt_name} can be counted.")
```
Output:
```
Event perf::PERF_COUNT_HW_CPU_CYCLES can be counted.
```

# Example - Event Not Countable

```python
from cypapi import *

# initialize cyPAPI
cyPAPI_library_init()

# check to see if cyPAPI has been intialized
if cyPAPI_is_initialized() != 1:
    raise Exception("cyPAPI was not successfully initialized.")

# using PAPI_VEC_DP - will not be countable 
evt_code = -2147483542

# see if event can be counted on this architecture
retval = cyPAPI_query_event(evt_code)
if retval != 0:
    raise Exception(f"Event {cyPAPI_event_code_to_name(evt_code)} is not countable with error code {retval}.")
```
Output:
```
Exception: Event PAPI_VEC_DP is not countable with error code -7.
```

Likewise the same will hold true for `cyPAPI_query_named_event( ... )` when passing "PAPI_VEC_DP".

Note: For `cyPAPI_query_event( ... )`, I have tested both the PAPI defines, negative integers, and hex codes with `PAPI_TOT_INS`, `PAPI_FP_OPS`, and `PAPI_VEC_DP`. Everything worked as expected when testing. 