### PR TITLE
Restructure cyPAPI_library_init and cyPAPI Versioning

### DIFF
--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -12,6 +12,16 @@ cdef void *libhndl = dlfcn.dlopen('libsde.so', dlfcn.RTLD_LAZY | dlfcn.RTLD_GLOB
 from papih cimport *
 from papiStdEventDefh cimport *
 
+# PAPI versioning
+PAPI_VER_CURRENT = _PAPI_VER_CURRENT
+PAPI_VERSION = _PAPI_VERSION
+
+# lambda functions to obtain PAPI version number; equivalent to C #define
+PAPI_VERSION_MAJOR = lambda x: ( <unsigned int>x >> 24 & <unsigned int>0xff )
+PAPI_VERSION_MINOR = lambda x: ( <unsigned int>x >> 16 & <unsigned int>0xff )
+PAPI_VERSION_REVISION = lambda x: ( <unsigned int>x >> 8 & <unsigned int>0xff )
+PAPI_VERSION_INCREMENT = lambda x: ( <unsigned int>x & <unsigned int>0xff )
+
 # importing PAPI preset #defines to be used in cyPAPI
 PAPI_L1_DCM = _PAPI_L1_DCM 
 PAPI_L1_ICM = _PAPI_L1_ICM 
@@ -125,10 +135,24 @@ PAPI_REF_CYC = _PAPI_REF_CYC
 PAPI_MAX_INFO_TERMS = _PAPI_MAX_INFO_TERMS
 PAPI_PMU_MAX = _PAPI_PMU_MAX
 
-def cyPAPI_library_init():
-    cdef int papi_errno = PAPI_library_init(PAPI_VER_CURRENT)
-    if papi_errno != PAPI_VER_CURRENT:
-        raise Exception('PAPI Error: Failed to initialize PAPI_Library')
+def cyPAPI_library_init(version):
+    """Initialize cyPAPI library with linked PAPI build.
+
+    Parameters
+    __________
+    version : int
+        Value of PAPI_VER_CURRENT.
+    """
+    cdef int retval
+    # check correct version is provided
+    if version != _PAPI_VER_CURRENT:
+        raise ValueError('Argument version only takes PAPI_VER_CURRENT.')
+    # check PAPI initialization was successful
+    retval = PAPI_library_init(version)
+    if retval != _PAPI_VER_CURRENT:
+        raise Exception( 'Failed initialization of cyPAPI. See if linked PAPI '
+                         'build was successfully installed.' )
+    return retval
 
 def cyPAPI_is_initialized():
     return PAPI_is_initialized()

--- a/cypapi/papih.pxd
+++ b/cypapi/papih.pxd
@@ -1,10 +1,6 @@
 cdef extern from 'papi.h':
-    int PAPI_VER_CURRENT
-    int PAPI_VERSION
-    int PAPI_VERSION_MAJOR(int)
-    int PAPI_VERSION_MINOR(int)
-    int PAPI_VERSION_REVISION(int)
-    int PAPI_VERSION_INCREMENT(int)
+    int _PAPI_VER_CURRENT "PAPI_VER_CURRENT"
+    int _PAPI_VERSION "PAPI_VERSION"
     int PAPI_library_init(int version)
     int PAPI_is_initialized()
     char *PAPI_strerror(int)


### PR DESCRIPTION
This PR addresses the following: 

1. Adding the argument `version` to `cyPAPI_library_init( version )`. 
2. Adding return value to `cyPAPI_library_init( version )`.
3. Making global variables `PAPI_VER_CURRENT` and `PAPI_VERSION` available to the user .
4. Adding global lambda functions: `PAPI_VERSION_MAJOR`, `PAPI_VERSION_MINOR`, `PAPI_VERSION_REVISION`, and `PAPI_VERSION_INCREMENT`. These are equivalent to the exact named #define's located in the PAPI header file. 

The argument `version` will only take `PAPI_VER_CURRENT`, otherwise a `ValueError` will be raised.  This is being done to be more in line with the behavior of `PAPI_library_init( int version )`. Along with the newly added argument to `cyPAPI_library_init( ... )`, a return value was also added. This return value can then be utilized with the added global lambda functions to obtain the major, minor, revision, and increment PAPI version values. See below for examples.


# Updated workflow for a user
Test code:
```python
from cypapi import *

# initialize cyPAPI
cyPAPI_library_init(PAPI_VER_CURRENT)

# check to see if cyPAPI has been intialized
if cyPAPI_is_initialized() == 1:
    print("cyPAPI was successfully initialized.")
```
Output: 
``` 
cyPAPI was successfully initialized.
```

# Workflow of utilizing global lambda functions to get PAPI version number
Test code:
```python
from cypapi import *

# initialize cyPAPI library
retval = cyPAPI_library_init(PAPI_VER_CURRENT)

# print out PAPI versioning
print("MAJOR:     ", PAPI_VERSION_MAJOR(retval))
print("MINOR:     ", PAPI_VERSION_MINOR(retval))
print("REVISION:  ", PAPI_VERSION_REVISION(retval))
print("INCREMENT: ", PAPI_VERSION_INCREMENT(retval))
```
Output:
```
MAJOR:      7
MINOR:      1
REVISION:   0
INCREMENT:  0
```
# Behavior if a user does not provide `PAPI_VER_CURRENT`
Test code:
```python
from cypapi import *

# initialize cyPAPI
cyPAPI_library_init(5)

# check to see if cyPAPI has been intialized
if cyPAPI_is_initialized() == 1:
    print("cyPAPI was successfully initialized.")
```
Output:
```
Traceback (most recent call last):
  File "/home/tburgess/jupyter-env/bin/cyPAPI/cypapi/test_version.py", line 4, in <module>
    cyPAPI_library_init(5)
  File "cypapi/cypapi.pyx", line 147, in cypapi.cyPAPI_library_init
    raise ValueError("Argument version only takes PAPI_VER_CURRENT.")
ValueError: Argument version only takes PAPI_VER_CURRENT.
```