### PR TITLE
Update cyPAPI to Support Cython >= 3.0.0

### DIFF
--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3
+# cython: language_level=3str
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 import atexit
 import warnings
@@ -618,9 +618,9 @@ cdef class CyPAPI_EventSet:
         if papi_errno != PAPI_OK:
             raise Exception(f'PAPI_Error {papi_errno}: Failed to cleanup eventset.')
 
-    def __del__(self):
-        self.cleanup()
-        cdef papi_errno = PAPI_destroy_eventset(&self.event_set)
+    def destroy_eventset(self):
+        cdef papi_errno
+        papi_errno = PAPI_destroy_eventset(&self.event_set)
         if papi_errno != PAPI_OK:
             raise Exception(f'PAPI_Errno {papi_errno}: Failed to destroy eventset.')
 

--- a/cypapi/cysdelib.pyx
+++ b/cypapi/cysdelib.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3
+# cython: language_level=3str
 cimport posix.dlfcn as dlfcn
 cdef void *libhndl = dlfcn.dlopen('libpapi.so', dlfcn.RTLD_LAZY | dlfcn.RTLD_GLOBAL)
 

--- a/cypapi/threadsampler.pyx
+++ b/cypapi/threadsampler.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3
+# cython: language_level=3str
 import threading
 cimport posix.unistd as unistd
 from libc.stdlib cimport malloc, free, calloc, realloc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools ~= 58.0", "cython ~= 0.29.0", "pkgconfig ~= 1.5.5", "numpy"]
+requires = ["setuptools ~= 58.0", "cython >= 3.0.0", "pkgconfig ~= 1.5.5", "numpy"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ def configure_extension(ext: Extension, papi_path: str):
 if os.name == 'nt':
     raise NotImplementedError('cypapi does not currently support Windows OS')
 
-ext_papi = Extension('cypapi', sources=['cypapi/cypapi.pyx'], libraries=['papi'], include_dirs=[numpy.get_include()])
-ext_sde = Extension('cysdelib', sources=['cypapi/cysdelib.pyx'], libraries=['papi', 'sde'])
-ext_papi_thr = Extension('cypapithr', sources=['cypapi/threadsampler.pyx'], libraries=['papi'], include_dirs=[numpy.get_include()])
+ext_papi = Extension('cypapi', sources=['cypapi/cypapi.pyx'], libraries=['papi'], include_dirs=[numpy.get_include()], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")])
+ext_sde = Extension('cysdelib', sources=['cypapi/cysdelib.pyx'], libraries=['papi', 'sde'], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")])
+ext_papi_thr = Extension('cypapithr', sources=['cypapi/threadsampler.pyx'], libraries=['papi'], include_dirs=[numpy.get_include()], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")])
 
 papi_path = os.environ.get('PAPI_PATH')
 if not papi_path:


### PR DESCRIPTION
This pull requests addresses:

1. Update `pyproject.toml` to have: 

    - Requirement of `cython >= 3.0.0`. 
 
2. Update `setup.py` to add:

    - `define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]` to all extensions. This was done to remove the build warning of using a deprecated Numpy version. Please see Cython [official documentation](https://cython.readthedocs.io/en/stable/src/userguide/migrating_to_cy30.html#numpy-c-api) for more details. 
 
3. Replaced  method `__del__()` from `CyPAPI_EventSet()` and added `.destroy_eventset()`. This was due to `__del__()` causing a segmentation fault in Cython 3.0.0.

4. Setting the `language_level` in `cypapi.pyx`, `threadsampler.pyx`, and `cysdelib.pyx` to `3str` which is the default. 

## Example Workflow of `.destroy_eventset()`

```python
from cypapi import *

# initialize cyPAPI
cyPAPI_library_init()

# check to see if cyPAPI has been intialized
if cyPAPI_is_initialized() != 1:
    raise Exception("cyPAPI was not successfully initialized.")

# create cyPAPI EventSet
eventset = CyPAPI_EventSet()

# add PAPI_TOT_INS to eventset
eventset.add_named_event("PAPI_TOT_INS")

# start counting
eventset.start()

# perform computation
for i in range(1, 10):
    i * 2 / i * 3

# stop counting
eventset.stop()

# cleanup eventset
eventset.cleanup()

# destroy eventset
eventset.destroy_eventset()

```