### PR TITLE
Adding cyPAPI_enum_event function to enumerate through events

### DIFF
--- a/cypapi/papiStdEventDefh.pxd
+++ b/cypapi/papiStdEventDefh.pxd
@@ -1,4 +1,8 @@
 cdef extern from "papiStdEventDefs.h":
+    # PAPI masks
+    cdef int _PAPI_PRESET_MASK "PAPI_PRESET_MASK"
+    cdef int _PAPI_NATIVE_MASK "PAPI_NATIVE_MASK"
+    # PAPI presets
     cdef int _PAPI_L1_DCM  "PAPI_L1_DCM"   # Level 1 data cache misses
     cdef int _PAPI_L1_ICM  "PAPI_L1_ICM"   # Level 1 instruction cache misses
     cdef int _PAPI_L2_DCM  "PAPI_L2_DCM"   # Level 2 data cache misses

--- a/cypapi/papih.pxd
+++ b/cypapi/papih.pxd
@@ -17,9 +17,15 @@ cdef extern from 'papi.h':
     cdef int PAPI_CLOCKRATE
     int  PAPI_get_opt(int option, void *ptr)
 
-    cdef int PAPI_NATIVE_MASK
-    cdef int PAPI_ENUM_FIRST
-    cdef int PAPI_ENUM_EVENTS
+    # generic PAPI modifiers
+    cdef int _PAPI_ENUM_FIRST "PAPI_ENUM_FIRST"
+    cdef int _PAPI_ENUM_EVENTS "PAPI_ENUM_EVENTS"
+    cdef int _PAPI_ENUM_ALL "PAPI_ENUM_ALL"
+    # preset PAPI modifiers
+    cdef int _PAPI_PRESET_ENUM_AVAIL "PAPI_PRESET_ENUM_AVAIL"
+    # native PAPI modifiers
+    cdef int _PAPI_NTV_ENUM_UMASKS "PAPI_NTV_ENUM_UMASKS"
+    cdef int _PAPI_NTV_ENUM_UMASK_COMBOS "PAPI_NTV_ENUM_UMASK_COMBOS"
     cdef int PAPI_MAX_STR_LEN
     cdef int PAPI_MIN_STR_LEN
     cdef int PAPI_HUGE_STR_LEN
@@ -75,20 +81,6 @@ cdef extern from 'papi.h':
     const PAPI_component_info_t *PAPI_get_component_info(int cidx)
 
     int PAPI_num_cmp_hwctrs(int cidx)
-    cdef int PAPI_PRESET_MASK
-    cdef int PAPI_PRESET_ENUM_AVAIL
-    cdef int PAPI_PRESET_ENUM_MSC
-    cdef int PAPI_PRESET_ENUM_INS
-    cdef int PAPI_PRESET_ENUM_IDL
-    cdef int PAPI_PRESET_ENUM_BR
-    cdef int PAPI_PRESET_ENUM_CND
-    cdef int PAPI_PRESET_ENUM_MEM
-    cdef int PAPI_PRESET_ENUM_CACH
-    cdef int PAPI_PRESET_ENUM_L1
-    cdef int PAPI_PRESET_ENUM_L2
-    cdef int PAPI_PRESET_ENUM_L3
-    cdef int PAPI_PRESET_ENUM_TLB
-    cdef int PAPI_PRESET_ENUM_FP
     int PAPI_enum_event(int *EventCode, int modifier)
     int PAPI_enum_cmp_event(int *EventCode, int modifier, int cidx)
     int PAPI_event_code_to_name(int EventCode, char *out)


### PR DESCRIPTION
This PR looks to add `cyPAPI_enum_event(EventCode, modifier)` into the cyPAPI library. The only difference between the cyPAPI implementation and PAPI implementation is `cyPAPI_enum_event` will return a tuple which contains a dictionary and updated eventcode. Besides the return type, the functionality is equivalent to the PAPI counterpart `PAPI_enum_event(int EventCode, int modifier)`. Demos can be seen below.

As a note, users will have to parse the returned tuple either by tuple unpacking or by numerically indexing into the tuple. Otherwise Python will raise a `ValueError` stating that there are too many values to unpack.

# Demo's for PAPI Preset Events
Script utilized for PAPI preset event demo's: 
```python
from cypapi import *

# initialize cyPAPI
cyPAPI_library_init(PAPI_VER_CURRENT)

# check to see if cyPAPI has been intialized
if cyPAPI_is_initialized() != 1:
    print("cyPAPI was not successfully initialized.")

# starting with first preset event
code = 0 | PAPI_PRESET_MASK
# available preset modifiers
modifier = [PAPI_ENUM_FIRST, PAPI_ENUM_EVENTS, PAPI_PRESET_ENUM_AVAIL]

# enumerate modifiers
for mod in modifier:
    # tuple unpacking to get dictionary and updated event code
    enum_dict, _  = cyPAPI_enum_event(code, mod)
    print('Dictionary Output: ',  enum_dict, '\n')
```
### Output for `modifier = PAPI_ENUM_FIRST`:
```
{'PAPI_L1_DCM': '0x80000000'}
```

### Output for `modifier = PAPI_ENUM_EVENTS`:
```
{'PAPI_L1_ICM': '0x80000001', 'PAPI_L2_DCM': '0x80000002', 'PAPI_L2_ICM': '0x80000003', 'PAPI_L3_DCM': '0x80000004', 'PAPI_L3_ICM': '0x80000005', 'PAPI_L1_TCM': '0x80000006', 'PAPI_L2_TCM': '0x80000007', 'PAPI_L3_TCM': '0x80000008', 'PAPI_CA_SNP': '0x80000009', 'PAPI_CA_SHR': '0x8000000a', 'PAPI_CA_CLN': '0x8000000b', 'PAPI_CA_INV': '0x8000000c', 'PAPI_CA_ITV': '0x8000000d', 'PAPI_L3_LDM': '0x8000000e', 'PAPI_L3_STM': '0x8000000f', 'PAPI_BRU_IDL': '0x80000010', 'PAPI_FXU_IDL': '0x80000011', 'PAPI_FPU_IDL': '0x80000012', 'PAPI_LSU_IDL': '0x80000013', 'PAPI_TLB_DM': '0x80000014', 'PAPI_TLB_IM': '0x80000015', 'PAPI_TLB_TL': '0x80000016', 'PAPI_L1_LDM': '0x80000017', 'PAPI_L1_STM': '0x80000018', 'PAPI_L2_LDM': '0x80000019', 'PAPI_L2_STM': '0x8000001a', 'PAPI_BTAC_M': '0x8000001b', 'PAPI_PRF_DM': '0x8000001c', 'PAPI_L3_DCH': '0x8000001d', 'PAPI_TLB_SD': '0x8000001e', 'PAPI_CSR_FAL': '0x8000001f', 'PAPI_CSR_SUC': '0x80000020', 'PAPI_CSR_TOT': '0x80000021', 'PAPI_MEM_SCY': '0x80000022', 'PAPI_MEM_RCY': '0x80000023', 'PAPI_MEM_WCY': '0x80000024', 'PAPI_STL_ICY': '0x80000025', 'PAPI_FUL_ICY': '0x80000026', 'PAPI_STL_CCY': '0x80000027', 'PAPI_FUL_CCY': '0x80000028', 'PAPI_HW_INT': '0x80000029', 'PAPI_BR_UCN': '0x8000002a', 'PAPI_BR_CN': '0x8000002b', 'PAPI_BR_TKN': '0x8000002c', 'PAPI_BR_NTK': '0x8000002d', 'PAPI_BR_MSP': '0x8000002e', 'PAPI_BR_PRC': '0x8000002f', 'PAPI_FMA_INS': '0x80000030', 'PAPI_TOT_IIS': '0x80000031', 'PAPI_TOT_INS': '0x80000032', 'PAPI_INT_INS': '0x80000033', 'PAPI_FP_INS': '0x80000034', 'PAPI_LD_INS': '0x80000035', 'PAPI_SR_INS': '0x80000036', 'PAPI_BR_INS': '0x80000037', 'PAPI_VEC_INS': '0x80000038', 'PAPI_RES_STL': '0x80000039', 'PAPI_FP_STAL': '0x8000003a', 'PAPI_TOT_CYC': '0x8000003b', 'PAPI_LST_INS': '0x8000003c', 'PAPI_SYC_INS': '0x8000003d', 'PAPI_L1_DCH': '0x8000003e', 'PAPI_L2_DCH': '0x8000003f', 'PAPI_L1_DCA': '0x80000040', 'PAPI_L2_DCA': '0x80000041', 'PAPI_L3_DCA': '0x80000042', 'PAPI_L1_DCR': '0x80000043', 'PAPI_L2_DCR': '0x80000044', 'PAPI_L3_DCR': '0x80000045', 'PAPI_L1_DCW': '0x80000046', 'PAPI_L2_DCW': '0x80000047', 'PAPI_L3_DCW': '0x80000048', 'PAPI_L1_ICH': '0x80000049', 'PAPI_L2_ICH': '0x8000004a', 'PAPI_L3_ICH': '0x8000004b', 'PAPI_L1_ICA': '0x8000004c', 'PAPI_L2_ICA': '0x8000004d', 'PAPI_L3_ICA': '0x8000004e', 'PAPI_L1_ICR': '0x8000004f', 'PAPI_L2_ICR': '0x80000050', 'PAPI_L3_ICR': '0x80000051', 'PAPI_L1_ICW': '0x80000052', 'PAPI_L2_ICW': '0x80000053', 'PAPI_L3_ICW': '0x80000054', 'PAPI_L1_TCH': '0x80000055', 'PAPI_L2_TCH': '0x80000056', 'PAPI_L3_TCH': '0x80000057', 'PAPI_L1_TCA': '0x80000058', 'PAPI_L2_TCA': '0x80000059', 'PAPI_L3_TCA': '0x8000005a', 'PAPI_L1_TCR': '0x8000005b', 'PAPI_L2_TCR': '0x8000005c', 'PAPI_L3_TCR': '0x8000005d', 'PAPI_L1_TCW': '0x8000005e', 'PAPI_L2_TCW': '0x8000005f', 'PAPI_L3_TCW': '0x80000060', 'PAPI_FML_INS': '0x80000061', 'PAPI_FAD_INS': '0x80000062', 'PAPI_FDV_INS': '0x80000063', 'PAPI_FSQ_INS': '0x80000064', 'PAPI_FNV_INS': '0x80000065', 'PAPI_FP_OPS': '0x80000066', 'PAPI_SP_OPS': '0x80000067', 'PAPI_DP_OPS': '0x80000068', 'PAPI_VEC_SP': '0x80000069', 'PAPI_VEC_DP': '0x8000006a', 'PAPI_REF_CYC': '0x8000006b'}
```
### Output for  `modifier = PAPI_PRESET_ENUM_AVAIL`:

```
{'PAPI_L1_ICM': '0x80000001', 'PAPI_L2_DCM': '0x80000002', 'PAPI_L2_ICM': '0x80000003', 'PAPI_L1_TCM': '0x80000006', 'PAPI_L2_TCM': '0x80000007', 'PAPI_L3_TCM': '0x80000008', 'PAPI_CA_SNP': '0x80000009', 'PAPI_CA_SHR': '0x8000000a', 'PAPI_CA_CLN': '0x8000000b', 'PAPI_CA_INV': '0x8000000c', 'PAPI_CA_ITV': '0x8000000d', 'PAPI_L3_LDM': '0x8000000e', 'PAPI_TLB_DM': '0x80000014', 'PAPI_TLB_IM': '0x80000015', 'PAPI_L1_LDM': '0x80000017', 'PAPI_L1_STM': '0x80000018', 'PAPI_L2_LDM': '0x80000019', 'PAPI_L2_STM': '0x8000001a', 'PAPI_PRF_DM': '0x8000001c', 'PAPI_MEM_WCY': '0x80000024', 'PAPI_STL_ICY': '0x80000025', 'PAPI_FUL_ICY': '0x80000026', 'PAPI_STL_CCY': '0x80000027', 'PAPI_FUL_CCY': '0x80000028', 'PAPI_BR_UCN': '0x8000002a', 'PAPI_BR_CN': '0x8000002b', 'PAPI_BR_TKN': '0x8000002c', 'PAPI_BR_NTK': '0x8000002d', 'PAPI_BR_MSP': '0x8000002e', 'PAPI_BR_PRC': '0x8000002f', 'PAPI_TOT_INS': '0x80000032', 'PAPI_LD_INS': '0x80000035', 'PAPI_SR_INS': '0x80000036', 'PAPI_BR_INS': '0x80000037', 'PAPI_RES_STL': '0x80000039', 'PAPI_TOT_CYC': '0x8000003b', 'PAPI_LST_INS': '0x8000003c', 'PAPI_L2_DCA': '0x80000041', 'PAPI_L3_DCA': '0x80000042', 'PAPI_L2_DCR': '0x80000044', 'PAPI_L3_DCR': '0x80000045', 'PAPI_L2_DCW': '0x80000047', 'PAPI_L3_DCW': '0x80000048', 'PAPI_L2_ICH': '0x8000004a', 'PAPI_L2_ICA': '0x8000004d', 'PAPI_L3_ICA': '0x8000004e', 'PAPI_L2_ICR': '0x80000050', 'PAPI_L3_ICR': '0x80000051', 'PAPI_L2_TCA': '0x80000059', 'PAPI_L3_TCA': '0x8000005a', 'PAPI_L2_TCR': '0x8000005c', 'PAPI_L3_TCR': '0x8000005d', 'PAPI_L2_TCW': '0x8000005f', 'PAPI_L3_TCW': '0x80000060', 'PAPI_SP_OPS': '0x80000067', 'PAPI_DP_OPS': '0x80000068', 'PAPI_VEC_SP': '0x80000069', 'PAPI_VEC_DP': '0x8000006a', 'PAPI_REF_CYC': '0x8000006b'}
```

# Demo's with  PAPI Native Events
Script utilized for PAPI native event demo's: 
```python
from cypapi import *

# initialize cyPAPI
cyPAPI_library_init(PAPI_VER_CURRENT)

# check to see if cyPAPI has been intialized
if cyPAPI_is_initialized() != 1:
    print("cyPAPI was not successfully initialized.")

# starting with first preset event
code = 0 | PAPI_NATIVE_MASK
# selecting modifier
modifier = [PAPI_ENUM_FIRST, PAPI_ENUM_EVENTS, PAPI_NTV_ENUM_UMASKS, PAPI_NTV_ENUM_UMASK_COMBOS]

# enumerate modifiers
for mod in modifier:
    enum_dict, code = cyPAPI_enum_event(code, mod)
    print('Dictionary Output: ', enum_dict, "\n")
```
### Output for `modifier = PAPI_ENUM_FIRST`:
```
{'ix86arch::UNHALTED_CORE_CYCLES': '0x4000002e'} 
```

### Output for `modifier = PAPI_ENUM_EVENTS`:
```
{'ix86arch::INSTRUCTION_RETIRED': '0x4000002f', 'ix86arch::UNHALTED_REFERENCE_CYCLES': '0x40000030', 'ix86arch::LLC_REFERENCES': '0x40000031', 'ix86arch::LLC_MISSES': '0x40000032', 'ix86arch::BRANCH_INSTRUCTIONS_RETIRED': '0x40000033', 'ix86arch::MISPREDICTED_BRANCH_RETIRED': '0x40000034', 'perf::PERF_COUNT_HW_CPU_CYCLES': '0x40000035', 'perf::CYCLES': '0x40000036', 'perf::CPU-CYCLES': '0x40000037', 'perf::PERF_COUNT_HW_INSTRUCTIONS': '0x40000038', 'perf::INSTRUCTIONS': '0x40000039', 'perf::PERF_COUNT_HW_CACHE_REFERENCES': '0x4000003a', 'perf::CACHE-REFERENCES': '0x4000003b', 'perf::PERF_COUNT_HW_CACHE_MISSES': '0x4000003c', 'perf::CACHE-MISSES': '0x4000003d', 'perf::PERF_COUNT_HW_BRANCH_INSTRUCTIONS': '0x4000003e', 'perf::BRANCH-INSTRUCTIONS': '0x4000003f', 'perf::BRANCHES': '0x40000040', 'perf::PERF_COUNT_HW_BRANCH_MISSES': '0x40000041', 'perf::BRANCH-MISSES': '0x40000042', 'perf::PERF_COUNT_HW_BUS_CYCLES': '0x40000043', 'perf::BUS-CYCLES': '0x40000044', 'perf::PERF_COUNT_HW_STALLED_CYCLES_FRONTEND': '0x40000045', 'perf::STALLED-CYCLES-FRONTEND': '0x40000046', 'perf::IDLE-CYCLES-FRONTEND': '0x40000047', 'perf::PERF_COUNT_HW_STALLED_CYCLES_BACKEND': '0x40000048', 'perf::STALLED-CYCLES-BACKEND': '0x40000049', 'perf::IDLE-CYCLES-BACKEND': '0x4000004a', 'perf::PERF_COUNT_HW_REF_CPU_CYCLES': '0x4000004b', 'perf::REF-CYCLES': '0x4000004c', 'perf::PERF_COUNT_SW_CPU_CLOCK': '0x4000004d', 'perf::CPU-CLOCK': '0x4000004e', 'perf::PERF_COUNT_SW_TASK_CLOCK': '0x4000004f', 'perf::TASK-CLOCK': '0x40000050', 'perf::PERF_COUNT_SW_PAGE_FAULTS': '0x40000051', 'perf::PAGE-FAULTS': '0x40000052', 'perf::FAULTS': '0x40000053', 'perf::PERF_COUNT_SW_CONTEXT_SWITCHES': '0x40000054', 'perf::CONTEXT-SWITCHES': '0x40000055', 'perf::CS': '0x40000056', 'perf::PERF_COUNT_SW_CPU_MIGRATIONS': '0x40000057', 'perf::CPU-MIGRATIONS': '0x40000058', 'perf::MIGRATIONS': '0x40000059', 'perf::PERF_COUNT_SW_PAGE_FAULTS_MIN': '0x4000005a', 'perf::MINOR-FAULTS': '0x4000005b', 'perf::PERF_COUNT_SW_PAGE_FAULTS_MAJ': '0x4000005c', 'perf::MAJOR-FAULTS': '0x4000005d', 'perf::PERF_COUNT_SW_CGROUP_SWITCHES': '0x4000005e', 'perf::CGROUP-SWITCHES': '0x4000005f', 'perf::PERF_COUNT_HW_CACHE_L1D': '0x40000060', 'perf::L1-DCACHE-LOADS': '0x40000061', 'perf::L1-DCACHE-LOAD-MISSES': '0x40000062', 'perf::L1-DCACHE-STORES': '0x40000063', 'perf::L1-DCACHE-STORE-MISSES': '0x40000064', 'perf::L1-DCACHE-PREFETCHES': '0x40000065', 'perf::L1-DCACHE-PREFETCH-MISSES': '0x40000066', 'perf::PERF_COUNT_HW_CACHE_L1I': '0x40000067', 'perf::L1-ICACHE-LOADS': '0x40000068', 'perf::L1-ICACHE-LOAD-MISSES': '0x40000069', 'perf::L1-ICACHE-PREFETCHES': '0x4000006a', 'perf::L1-ICACHE-PREFETCH-MISSES': '0x4000006b', 'perf::PERF_COUNT_HW_CACHE_LL': '0x4000006c', 'perf::LLC-LOADS': '0x4000006d', 'perf::LLC-LOAD-MISSES': '0x4000006e', 'perf::LLC-STORES': '0x4000006f', 'perf::LLC-STORE-MISSES': '0x40000070', 'perf::LLC-PREFETCHES': '0x40000071', 'perf::LLC-PREFETCH-MISSES': '0x40000072', 'perf::PERF_COUNT_HW_CACHE_DTLB': '0x40000073', 'perf::DTLB-LOADS': '0x40000074', 'perf::DTLB-LOAD-MISSES': '0x40000075', 'perf::DTLB-STORES': '0x40000076', 'perf::DTLB-STORE-MISSES': '0x40000077', 'perf::DTLB-PREFETCHES': '0x40000078', 'perf::DTLB-PREFETCH-MISSES': '0x40000079', 'perf::PERF_COUNT_HW_CACHE_ITLB': '0x4000007a', 'perf::ITLB-LOADS': '0x4000007b', 'perf::ITLB-LOAD-MISSES': '0x4000007c', 'perf::PERF_COUNT_HW_CACHE_BPU': '0x4000007d', 'perf::BRANCH-LOADS': '0x4000007e', 'perf::BRANCH-LOAD-MISSES': '0x4000007f', 'perf::PERF_COUNT_HW_CACHE_NODE': '0x40000080', 'perf::NODE-LOADS': '0x40000081', 'perf::NODE-LOAD-MISSES': '0x40000082', 'perf::NODE-STORES': '0x40000083', 'perf::NODE-STORE-MISSES': '0x40000084', 'perf::NODE-PREFETCHES': '0x40000085', 'perf::NODE-PREFETCH-MISSES': '0x40000086', 'perf_raw::r0000': '0x40000087', 'UNHALTED_CORE_CYCLES': '0x40000088', 'UNHALTED_REFERENCE_CYCLES': '0x40000089', 'INSTRUCTION_RETIRED': '0x4000008a', 'INSTRUCTIONS_RETIRED': '0x4000008b', 'BRANCH_INSTRUCTIONS_RETIRED': '0x4000008c', 'MISPREDICTED_BRANCH_RETIRED': '0x4000008d', 'BACLEARS': '0x4000008e', 'BR_INST_EXEC': '0x4000008f', 'BR_INST_RETIRED': '0x40000090', 'BR_MISP_EXEC': '0x40000091', 'BR_MISP_RETIRED': '0x40000092', 'CPL_CYCLES': '0x40000093', 'CPU_CLK_THREAD_UNHALTED': '0x40000094', 'CPU_CLK_UNHALTED': '0x40000095', 'CYCLE_ACTIVITY': '0x40000096', 'DTLB_LOAD_MISSES': '0x40000097', 'DTLB_STORE_MISSES': '0x40000098', 'FP_ASSIST': '0x40000099', 'HLE_RETIRED': '0x4000009a', 'ICACHE': '0x4000009b', 'IDQ': '0x4000009c', 'IDQ_UOPS_NOT_DELIVERED': '0x4000009d', 'INST_RETIRED': '0x4000009e', 'INT_MISC': '0x4000009f', 'ITLB': '0x400000a0', 'ITLB_MISSES': '0x400000a1', 'L1D': '0x400000a2', 'L1D_PEND_MISS': '0x400000a3', 'L2_DEMAND_RQSTS': '0x400000a4', 'L2_LINES_IN': '0x400000a5', 'L2_LINES_OUT': '0x400000a6', 'L2_RQSTS': '0x400000a7', 'L2_TRANS': '0x400000a8', 'LD_BLOCKS': '0x400000a9', 'LD_BLOCKS_PARTIAL': '0x400000aa', 'LOAD_HIT_PRE': '0x400000ab', 'LOCK_CYCLES': '0x400000ac', 'LONGEST_LAT_CACHE': '0x400000ad', 'MACHINE_CLEARS': '0x400000ae', 'MEM_LOAD_UOPS_L3_HIT_RETIRED': '0x400000af', 'MEM_LOAD_UOPS_LLC_HIT_RETIRED': '0x400000b0', 'MEM_LOAD_UOPS_L3_MISS_RETIRED': '0x400000b1', 'MEM_LOAD_UOPS_LLC_MISS_RETIRED': '0x400000b2', 'MEM_LOAD_UOPS_RETIRED': '0x400000b3', 'MEM_TRANS_RETIRED': '0x400000b4', 'MEM_UOPS_RETIRED': '0x400000b5', 'MISALIGN_MEM_REF': '0x400000b6', 'MOVE_ELIMINATION': '0x400000b7', 'OFFCORE_REQUESTS': '0x400000b8', 'OTHER_ASSISTS': '0x400000b9', 'RESOURCE_STALLS': '0x400000ba', 'ROB_MISC_EVENTS': '0x400000bb', 'RS_EVENTS': '0x400000bc', 'RTM_RETIRED': '0x400000bd', 'TLB_FLUSH': '0x400000be', 'UOPS_EXECUTED': '0x400000bf', 'LSD': '0x400000c0', 'UOPS_EXECUTED_PORT': '0x400000c1', 'UOPS_ISSUED': '0x400000c2', 'ARITH': '0x400000c3', 'UOPS_RETIRED': '0x400000c4', 'TX_MEM': '0x400000c5', 'TX_EXEC': '0x400000c6', 'OFFCORE_REQUESTS_OUTSTANDING': '0x400000c7', 'ILD_STALL': '0x400000c8', 'PAGE_WALKER_LOADS': '0x400000c9', 'DSB2MITE_SWITCHES': '0x400000ca', 'EPT': '0x400000cb', 'FP_ARITH': '0x400000cc', 'FP_ARITH_INST_RETIRED': '0x400000cd', 'OFFCORE_REQUESTS_BUFFER': '0x400000ce', 'UOPS_DISPATCHES_CANCELLED': '0x400000cf', 'SQ_MISC': '0x400000d0', 'OFFCORE_RESPONSE_0': '0x400000d1', 'OFFCORE_RESPONSE_1': '0x400000d2'} 
``` 

### Output for `modifier = PAPI_NTV_ENUM_UMASKS`:
```
{'OFFCORE_RESPONSE_1:DMND_DATA_RD': '0x400000d3', 'OFFCORE_RESPONSE_1:DMND_RFO': '0x400000d4', 'OFFCORE_RESPONSE_1:DMND_CODE_RD': '0x400000d5', 'OFFCORE_RESPONSE_1:DMND_IFETCH': '0x400000d6', 'OFFCORE_RESPONSE_1:WB': '0x400000d7', 'OFFCORE_RESPONSE_1:PF_DATA_RD': '0x400000d8', 'OFFCORE_RESPONSE_1:PF_RFO': '0x400000d9', 'OFFCORE_RESPONSE_1:PF_IFETCH': '0x400000da', 'OFFCORE_RESPONSE_1:PF_LLC_DATA_RD': '0x400000db', 'OFFCORE_RESPONSE_1:PF_LLC_RFO': '0x400000dc', 'OFFCORE_RESPONSE_1:PF_LLC_IFETCH': '0x400000dd', 'OFFCORE_RESPONSE_1:BUS_LOCKS': '0x400000de', 'OFFCORE_RESPONSE_1:STRM_ST': '0x400000df', 'OFFCORE_RESPONSE_1:OTHER': '0x400000e0', 'OFFCORE_RESPONSE_1:ANY_IFETCH': '0x400000e1', 'OFFCORE_RESPONSE_1:ANY_REQUEST': '0x400000e2', 'OFFCORE_RESPONSE_1:ANY_DATA': '0x400000e3', 'OFFCORE_RESPONSE_1:ANY_RFO': '0x400000e4', 'OFFCORE_RESPONSE_1:ANY_RESPONSE': '0x400000e5', 'OFFCORE_RESPONSE_1:NO_SUPP': '0x400000e6', 'OFFCORE_RESPONSE_1:L3_HITM': '0x400000e7', 'OFFCORE_RESPONSE_1:LLC_HITM': '0x400000e8', 'OFFCORE_RESPONSE_1:L3_HITE': '0x400000e9', 'OFFCORE_RESPONSE_1:LLC_HITE': '0x400000ea', 'OFFCORE_RESPONSE_1:L3_HITS': '0x400000eb', 'OFFCORE_RESPONSE_1:LLC_HITS': '0x400000ec', 'OFFCORE_RESPONSE_1:L3_HITF': '0x400000ed', 'OFFCORE_RESPONSE_1:LLC_HITF': '0x400000ee', 'OFFCORE_RESPONSE_1:L3_HITMESF': '0x400000ef', 'OFFCORE_RESPONSE_1:LLC_HITMESF': '0x400000f0', 'OFFCORE_RESPONSE_1:L3_HIT': '0x400000f1', 'OFFCORE_RESPONSE_1:LLC_HIT': '0x400000f2', 'OFFCORE_RESPONSE_1:L3_MISS_LOCAL': '0x400000f3', 'OFFCORE_RESPONSE_1:LLC_MISS_LOCAL': '0x400000f4', 'OFFCORE_RESPONSE_1:LLC_MISS_LOCAL_DRAM': '0x400000f5', 'OFFCORE_RESPONSE_1:L3_MISS': '0x400000f6', 'OFFCORE_RESPONSE_1:L3_MISS_REMOTE_HOP0': '0x400000f7', 'OFFCORE_RESPONSE_1:L3_MISS_REMOTE_HOP0_DRAM': '0x400000f8', 'OFFCORE_RESPONSE_1:L3_MISS_REMOTE_HOP1': '0x400000f9', 'OFFCORE_RESPONSE_1:L3_MISS_REMOTE_HOP1_DRAM': '0x400000fa', 'OFFCORE_RESPONSE_1:L3_MISS_REMOTE_HOP2P': '0x400000fb', 'OFFCORE_RESPONSE_1:L3_MISS_REMOTE_HOP2P_DRAM': '0x400000fc', 'OFFCORE_RESPONSE_1:L3_MISS_REMOTE': '0x400000fd', 'OFFCORE_RESPONSE_1:L3_MISS_REMOTE_DRAM': '0x400000fe', 'OFFCORE_RESPONSE_1:SPL_HIT': '0x400000ff', 'OFFCORE_RESPONSE_1:SNP_NONE': '0x40000100', 'OFFCORE_RESPONSE_1:SNP_NOT_NEEDED': '0x40000101', 'OFFCORE_RESPONSE_1:SNP_MISS': '0x40000102', 'OFFCORE_RESPONSE_1:SNP_NO_FWD': '0x40000103', 'OFFCORE_RESPONSE_1:SNP_FWD': '0x40000104', 'OFFCORE_RESPONSE_1:HITM': '0x40000105', 'OFFCORE_RESPONSE_1:SNP_HITM': '0x40000106', 'OFFCORE_RESPONSE_1:NON_DRAM': '0x40000107', 'OFFCORE_RESPONSE_1:SNP_ANY': '0x40000108', 'OFFCORE_RESPONSE_1:e=0': '0x40000109', 'OFFCORE_RESPONSE_1:i=0': '0x4000010a', 'OFFCORE_RESPONSE_1:c=0': '0x4000010b', 'OFFCORE_RESPONSE_1:t=0': '0x4000010c', 'OFFCORE_RESPONSE_1:intx=0': '0x4000010d', 'OFFCORE_RESPONSE_1:intxcp=0': '0x4000010e', 'OFFCORE_RESPONSE_1:u=0': '0x4000010f', 'OFFCORE_RESPONSE_1:k=0': '0x40000110', 'OFFCORE_RESPONSE_1:period=0': '0x40000111', 'OFFCORE_RESPONSE_1:freq=0': '0x40000112', 'OFFCORE_RESPONSE_1:excl=0': '0x40000113', 'OFFCORE_RESPONSE_1:mg=0': '0x40000114', 'OFFCORE_RESPONSE_1:mh=0': '0x40000115', 'OFFCORE_RESPONSE_1:cpu=0': '0x40000116', 'OFFCORE_RESPONSE_1:pinned=0': '0x40000117'} 
```

### Output for `modifier = PAPI_NTV_ENUM_UMASK_COMBOS`:
```
{}
```
