### PR TITLE
Updating function and class names to be equivalent to PAPI function names in C

### DIFF
--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -255,7 +255,7 @@ cdef void _PAPI_enum_cmp_event(int *EventCode, int modifier, int cidx) except *:
     if papi_errno == PAPI_ENOEVNT or papi_errno == PAPI_EINVAL:
         raise StopIteration
 
-cdef class CyPAPI_enum_component_events:
+cdef class CypapiEnumCmpEvent:
     cdef int ntv_code
     cdef int cidx
     cdef int modifier
@@ -598,7 +598,7 @@ class CypapiGetEventInfo:
                       for idx in range(0, _PAPI_MAX_INFO_TERMS) ]
         self.note = str(info.note, encoding = 'utf-8')
 
-cdef class CyPAPI_EventSet:
+cdef class CypapiCreateEventset:
     cdef int event_set
 
     def __cinit__(self):
@@ -613,7 +613,7 @@ cdef class CyPAPI_EventSet:
     def get_id(self):
         return self.event_set
 
-    def cleanup(self):
+    def cleanup_eventset(self):
         cdef papi_errno = PAPI_cleanup_eventset(self.event_set)
         if papi_errno != PAPI_OK:
             raise Exception(f'PAPI_Error {papi_errno}: Failed to cleanup eventset.')
@@ -627,7 +627,7 @@ cdef class CyPAPI_EventSet:
     def num_events(self):
         return PAPI_num_events(self.event_set)
 
-    def assign_component(self, int cidx):
+    def assign_eventset_component(self, int cidx):
         cdef int papi_errno = PAPI_assign_eventset_component(self.event_set, cidx)
         if papi_errno != PAPI_OK:
             raise Exception(f'PAPI Error {papi_errno}: Failed to assign component to eventset {self.event_set}')
@@ -752,7 +752,7 @@ cdef class CyPAPI_EventSet:
         if papi_errno != PAPI_OK:
             raise Exception(f'PAPI Error {papi_errno}: PAPI_write failed')
 
-    def get_component(self):
+    def get_eventset_component(self):
         cdef int cid = PAPI_get_eventset_component(self.event_set)
         if cid < 0:
             raise Exception(f'PAPI Error {cid}: Failed to get eventset component index')


### PR DESCRIPTION
This PR addresses updating cyPAPI method and class names to equivalent PAPI function names in C. A table below outlines these changes.
### Name Changes in`cypapi.pyx`

| PAPI Function Name | Previous cyPAPI Name | Updated cyPAPI Name |
| ------------- | ------------- | ------------- |
| `PAPI_enum_cmp_event` | `CyPAPI_enum_component_events` | `CypapiEnumCmpEvent` |
| `PAPI_create_eventset` | `CyPAPI_EventSet`  | `CypapiCreateEventset` |
| `PAPI_cleanup_eventset` | `.cleanup`  | `.cleanup_eventset` |
| `PAPI_assign_eventset_component` | `.assign_component`  | `.assign_eventset_component` |
| `PAPI_get_eventset_component` | `.get_component`  | `.get_eventset_component` |

Note: Class names follow the camel case convention in Python.

### Code Demo of Name Changes Implemented

Code:
```python
from cypapi import *

# initialize cyPAPI library
cyPAPI_library_init()

# make sure cyPAPI was initialized successfully
if cyPAPI_is_initialized() != 1:
    raise ValueError('cyPAPI was not successfully initialized.')

# enumerating through CPU events
cmp = CypapiEnumCmpEvent(0)
collected_evt_names = []
while(True):
    try:
        eventcode = cmp.next_event()
        eventname = cyPAPI_event_code_to_name(eventcode)
        collected_evt_names.append(eventname)
    except:
        break
print('CPU component event names are: ', collected_evt_names)

# create an eventset
EventSet = CypapiCreateEventset()
# verify eventset has been created
print('EventSet ID is: ', EventSet)
# add event to eventset
EventSet.add_named_event('PAPI_TOT_INS')
# verify event has been added
print('Number of events in EventSet is: ', EventSet.num_events())
# cleanup eventset
EventSet.cleanup_eventset()
# verify eventset has been cleaned up
print('Number of events in EventSet after cleanup: ', EventSet.num_events())

# verify assign cpu component and get cpu component
EventSet.assign_eventset_component(0)
print('EventSet has assigned component: ', EventSet.get_eventset_component())
```
Output to verify `CypapiEnumCmpEvent`:
```
['ix86arch::UNHALTED_CORE_CYCLES', 'ix86arch::INSTRUCTION_RETIRED', 'ix86arch::UNHALTED_REFERENCE_CYCLES', 'ix86arch::LLC_REFERENCES', 'ix86arch::LLC_MISSES', 'ix86arch::BRANCH_INSTRUCTIONS_RETIRED', 'ix86arch::MISPREDICTED_BRANCH_RETIRED', 'perf::PERF_COUNT_HW_CPU_CYCLES', 'perf::CYCLES', 'perf::CPU-CYCLES', 'perf::PERF_COUNT_HW_INSTRUCTIONS', 'perf::INSTRUCTIONS', 'perf::PERF_COUNT_HW_CACHE_REFERENCES', 'perf::CACHE-REFERENCES', 'perf::PERF_COUNT_HW_CACHE_MISSES', 'perf::CACHE-MISSES', 'perf::PERF_COUNT_HW_BRANCH_INSTRUCTIONS', 'perf::BRANCH-INSTRUCTIONS', 'perf::BRANCHES', 'perf::PERF_COUNT_HW_BRANCH_MISSES', 'perf::BRANCH-MISSES', 'perf::PERF_COUNT_HW_BUS_CYCLES', 'perf::BUS-CYCLES', 'perf::PERF_COUNT_HW_STALLED_CYCLES_FRONTEND', 'perf::STALLED-CYCLES-FRONTEND', 'perf::IDLE-CYCLES-FRONTEND', 'perf::PERF_COUNT_HW_STALLED_CYCLES_BACKEND', 'perf::STALLED-CYCLES-BACKEND', 'perf::IDLE-CYCLES-BACKEND', 'perf::PERF_COUNT_HW_REF_CPU_CYCLES', 'perf::REF-CYCLES', 'perf::PERF_COUNT_SW_CPU_CLOCK', 'perf::CPU-CLOCK', 'perf::PERF_COUNT_SW_TASK_CLOCK', 'perf::TASK-CLOCK', 'perf::PERF_COUNT_SW_PAGE_FAULTS', 'perf::PAGE-FAULTS', 'perf::FAULTS', 'perf::PERF_COUNT_SW_CONTEXT_SWITCHES', 'perf::CONTEXT-SWITCHES', 'perf::CS', 'perf::PERF_COUNT_SW_CPU_MIGRATIONS', 'perf::CPU-MIGRATIONS', 'perf::MIGRATIONS', 'perf::PERF_COUNT_SW_PAGE_FAULTS_MIN', 'perf::MINOR-FAULTS', 'perf::PERF_COUNT_SW_PAGE_FAULTS_MAJ', 'perf::MAJOR-FAULTS', 'perf::PERF_COUNT_SW_CGROUP_SWITCHES', 'perf::CGROUP-SWITCHES', 'perf::PERF_COUNT_HW_CACHE_L1D', 'perf::L1-DCACHE-LOADS', 'perf::L1-DCACHE-LOAD-MISSES', 'perf::L1-DCACHE-STORES', 'perf::L1-DCACHE-STORE-MISSES', 'perf::L1-DCACHE-PREFETCHES', 'perf::L1-DCACHE-PREFETCH-MISSES', 'perf::PERF_COUNT_HW_CACHE_L1I', 'perf::L1-ICACHE-LOADS', 'perf::L1-ICACHE-LOAD-MISSES', 'perf::L1-ICACHE-PREFETCHES', 'perf::L1-ICACHE-PREFETCH-MISSES', 'perf::PERF_COUNT_HW_CACHE_LL', 'perf::LLC-LOADS', 'perf::LLC-LOAD-MISSES', 'perf::LLC-STORES', 'perf::LLC-STORE-MISSES', 'perf::LLC-PREFETCHES', 'perf::LLC-PREFETCH-MISSES', 'perf::PERF_COUNT_HW_CACHE_DTLB', 'perf::DTLB-LOADS', 'perf::DTLB-LOAD-MISSES', 'perf::DTLB-STORES', 'perf::DTLB-STORE-MISSES', 'perf::DTLB-PREFETCHES', 'perf::DTLB-PREFETCH-MISSES', 'perf::PERF_COUNT_HW_CACHE_ITLB', 'perf::ITLB-LOADS', 'perf::ITLB-LOAD-MISSES', 'perf::PERF_COUNT_HW_CACHE_BPU', 'perf::BRANCH-LOADS', 'perf::BRANCH-LOAD-MISSES', 'perf::PERF_COUNT_HW_CACHE_NODE', 'perf::NODE-LOADS', 'perf::NODE-LOAD-MISSES', 'perf::NODE-STORES', 'perf::NODE-STORE-MISSES', 'perf::NODE-PREFETCHES', 'perf::NODE-PREFETCH-MISSES', 'perf_raw::r0000', 'UNHALTED_CORE_CYCLES', 'UNHALTED_REFERENCE_CYCLES', 'INSTRUCTION_RETIRED', 'INSTRUCTIONS_RETIRED', 'BRANCH_INSTRUCTIONS_RETIRED', 'MISPREDICTED_BRANCH_RETIRED', 'BACLEARS', 'BR_INST_EXEC', 'BR_INST_RETIRED', 'BR_MISP_EXEC', 'BR_MISP_RETIRED', 'CPL_CYCLES', 'CPU_CLK_THREAD_UNHALTED', 'CPU_CLK_UNHALTED', 'CYCLE_ACTIVITY', 'DTLB_LOAD_MISSES', 'DTLB_STORE_MISSES', 'FP_ASSIST', 'HLE_RETIRED', 'ICACHE', 'IDQ', 'IDQ_UOPS_NOT_DELIVERED', 'INST_RETIRED', 'INT_MISC', 'ITLB', 'ITLB_MISSES', 'L1D', 'L1D_PEND_MISS', 'L2_DEMAND_RQSTS', 'L2_LINES_IN', 'L2_LINES_OUT', 'L2_RQSTS', 'L2_TRANS', 'LD_BLOCKS', 'LD_BLOCKS_PARTIAL', 'LOAD_HIT_PRE', 'LOCK_CYCLES', 'LONGEST_LAT_CACHE', 'MACHINE_CLEARS', 'MEM_LOAD_UOPS_L3_HIT_RETIRED', 'MEM_LOAD_UOPS_LLC_HIT_RETIRED', 'MEM_LOAD_UOPS_L3_MISS_RETIRED', 'MEM_LOAD_UOPS_LLC_MISS_RETIRED', 'MEM_LOAD_UOPS_RETIRED', 'MEM_TRANS_RETIRED', 'MEM_UOPS_RETIRED', 'MISALIGN_MEM_REF', 'MOVE_ELIMINATION', 'OFFCORE_REQUESTS', 'OTHER_ASSISTS', 'RESOURCE_STALLS', 'ROB_MISC_EVENTS', 'RS_EVENTS', 'RTM_RETIRED', 'TLB_FLUSH', 'UOPS_EXECUTED', 'LSD', 'UOPS_EXECUTED_PORT', 'UOPS_ISSUED', 'ARITH', 'UOPS_RETIRED', 'TX_MEM', 'TX_EXEC', 'OFFCORE_REQUESTS_OUTSTANDING', 'ILD_STALL', 'PAGE_WALKER_LOADS', 'DSB2MITE_SWITCHES', 'EPT', 'FP_ARITH', 'FP_ARITH_INST_RETIRED', 'OFFCORE_REQUESTS_BUFFER', 'UOPS_DISPATCHES_CANCELLED', 'SQ_MISC', 'OFFCORE_RESPONSE_0', 'OFFCORE_RESPONSE_1']
```
Output to verify `CypapiCreateEventSet`:
```
EventSet ID is:  PAPI Event set 0
```
Output to verify `.cleanup_eventset`:
```
Number of events in EventSet is:  1
Number of events in EventSet after cleanup:  0
```

Output to verify `.assign_eventset_component` and `get_eventset_component`:
```
EventSet has assigned component:  0
```

