### PR TITLE
Make EventSet ID output for cyPAPI equivalent to PAPI

### DIFF
--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -608,10 +608,7 @@ cdef class CypapiCreateEventset:
             raise Exception(f'PAPI_Error {papi_errno}: Failed to create PAPI Event set.')
 
     def __str__(self):
-        return f'PAPI Event set {self.event_set}'
-
-    def get_id(self):
-        return self.event_set
+        return f'{self.event_set}'
 
     def cleanup_eventset(self):
         cdef papi_errno = PAPI_cleanup_eventset(self.event_set)


### PR DESCRIPTION
This PR addresses removing `.get_id()` due to to the functionality not being in the C framework of PAPI. In the place of `.get_id()`, the method `__str__` in `CyPAPI_EventSet`will be updated such that it is equivalent to printing out the EventSet ID in PAPI. 

## Printing EventSet ID in PAPI
Code:
```c
#include "papi.h"

#include <stdio.h>

int main() {
    int EventSet_one = PAPI_NULL, EventSet_two = PAPI_NULL, retval;

    retval = PAPI_library_init(PAPI_VER_CURRENT);
    if(retval != PAPI_VER_CURRENT) {
        printf("Failed to initialize PAPI.\n");
        return retval;
    }
    
    retval = PAPI_create_eventset(&EventSet_one);
    if(retval != PAPI_OK) {
        printf("Could not create first eventset.\n");
        return retval;
    }

    retval = PAPI_create_eventset(&EventSet_two); 
    if(retval != PAPI_OK) {                                                        
        printf("Could not create second eventset.\n");                                
        return retval;                                                             
    } 

    printf("EventSet_one id: %d\n", EventSet_one);
    printf("EventSet_two id: %d\n", EventSet_two);

    return retval;

}
```
Output:
```
EventSet_one id: 0
EventSet_two id: 1
```

## Printing `CyPAPI_EventSet` Object (ID) in cyPAPI
Code:
```python
from cypapi import *

# initialize cyPAPI library
cyPAPI_library_init(PAPI_VER_CURRENT)

# make sure cyPAPI was initialized successfully
if cyPAPI_is_initialized() != 1:
    raise ValueError('cyPAPI was not successfully initialized.')

# create first eventset
EventSet_one = CypapiCreateEventset()
# create second eventset
EventSet_two = CypapiCreateEventset()

# output eventset id's
print('EventSet_one id: ', EventSet_one)
print('EventSet_two id: ', EventSet_two)
```
Output:
```
EventSet_one id:  0
EventSet_two id:  1
```