### PR TITLE
Replace PAPI_PATH with PAPI_DIR in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ ext_papi = Extension('cypapi', sources=['cypapi/cypapi.pyx'], libraries=['papi']
 ext_sde = Extension('cysdelib', sources=['cypapi/cysdelib.pyx'], libraries=['papi', 'sde'], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")])
 ext_papi_thr = Extension('cypapithr', sources=['cypapi/threadsampler.pyx'], libraries=['papi'], include_dirs=[numpy.get_include()], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")])
 
-papi_path = os.environ.get('PAPI_PATH')
+papi_path = os.environ.get('PAPI_DIR')
 if not papi_path:
     papi_path = get_papi_path_pkg_config()
 if not papi_path:


### PR DESCRIPTION
Running `make install` today (June 18th, 2024) resulted in not successfully building cyPAPI. After looking further into this a PAPI build was not being correctly found.

When looking into the `setup.py` file, the following line of code exists `papi_path = os.environ.get('PAPI_PATH')`. Replacing `PAPI_PATH` with `PAPI_DIR` will fix this issue of not successfully building. 

This is also more in line with what the [PAPI documentation](https://github.com/icl-utk-edu/papi/wiki/Downloading-and-Installing-PAPI) recommends to do in **Step 4** of Downloading and Installing PAPI.