### PR TITLE
Adding Custom Exception's for cyPAPI

### DIFF
--- a/cypapi/__init__.py
+++ b/cypapi/__init__.py
@@ -1,0 +1,2 @@
+from .cypapi import *
+from .cypapi_exceptions import *

--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -1,7 +1,8 @@
 # cython: language_level=3str
-import numpy as np
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from dataclasses import dataclass, field, InitVar
+
+import numpy as np
 
 cimport numpy as np
 cimport posix.dlfcn as dlfcn

--- a/cypapi/cypapi_exceptions.py
+++ b/cypapi/cypapi_exceptions.py
@@ -31,7 +31,7 @@ class CypapiEnotrun(Exception):
     """No events or event sets are currently not counting."""
 
 class CypapiEisrun(Exception):
-    """Event Set is currently running."""
+    """Event set is currently running."""
 
 class CypapiEnoevst(Exception):
     """No such event set available."""
@@ -61,10 +61,10 @@ class CypapiEnoimpl(Exception):
     """Not implemented."""
 
 class CypapiEbuf(Exception):
-    """Buffer size exceeded"""
+    """Buffer size exceeded."""
 
 class CypapiEinvalDom(Exception):
-    """EventSet domain is not uspported for the operation."""
+    """Event set domain is not uspported for the operation."""
 
 class CypapiEattr(Exception):
     """Invalid or missing event attributes."""

--- a/cypapi/cypapi_exceptions.py
+++ b/cypapi/cypapi_exceptions.py
@@ -1,0 +1,117 @@
+class CypapiEinval(Exception):
+    """Invalid argument."""
+
+class CypapiEnomem(Exception):
+    """Insufficient memory."""
+
+class CypapiEsys(Exception):
+    """A system or C library call failed, please check errno."""
+
+class CypapiEcmp(Exception):
+    """Not supported by component"""
+
+class CypapiEsbstr(Exception):
+    """Substrate returned an error, usually the result of an unimplemented
+    feature."""
+
+class CypapiEclost(Exception):
+    """Access to the counters was lost or interrupted."""
+
+class CypapiEbug(Exception):
+    """Internal error, please send email to the developers."""
+
+class CypapiEnoevnt(Exception):
+    """Hardware event does not exist."""
+
+class CypapiEcnflct(Exception):
+    """Hardware event exists, but cannot be counted due to counter resource 
+    limitations."""
+
+class CypapiEnotrun(Exception):
+    """No events or event sets are currently not counting."""
+
+class CypapiEisrun(Exception):
+    """Event Set is currently running."""
+
+class CypapiEnoevst(Exception):
+    """No such event set available."""
+
+class CypapiEnotpreset(Exception):
+    """Event is not a valid preset."""
+
+class CypapiEnocntr(Exception):
+    """Hardware does not support performance counters."""
+
+class CypapiEmisc(Exception):
+    """Unknown error code."""
+
+class CypapiEperm(Exception):
+    """You lack the necessary permissions."""
+
+class CypapiEnoinit(Exception):
+    """PAPI hasn't been initialized yet."""
+
+class CypapiEnocmp(Exception):
+    """Component index isn't set."""
+
+class CypapiEnosupp(Exception):
+    """Not supported."""
+
+class CypapiEnoimpl(Exception):
+    """Not implemented."""
+
+class CypapiEbuf(Exception):
+    """Buffer size exceeded"""
+
+class CypapiEinvalDom(Exception):
+    """EventSet domain is not uspported for the operation."""
+
+class CypapiEattr(Exception):
+    """Invalid or missing event attributes."""
+
+class CypapiEcount(Exception):
+    """Too many events or attributes."""
+
+class CypapiEcombo(Exception):
+    """Bad combination of features."""
+
+class CypapiEcmpDisabled(Exception):
+    """Component containing event is disabled."""
+
+class CypapiEdelayInit(Exception):
+    """Delayed initialization component."""
+
+class CypapiEmulpass(Exception):
+    """Event exists, but cannot be counted due to multiple passes required by
+    hardware."""
+
+# dictionary to be used to raise custom exception based on PAPI error code
+_exceptions_for_cypapi = {
+   -1: CypapiEinval('Invalid argument (PAPI_EINVAL -1).'),
+   -2: CypapiEnomem('Insufficient memory (PAPI_ENOMEM -2).'),
+   -3: CypapiEsys('A system or C library call failed (PAPI_ESYS -3).'),
+   -4: CypapiEcmp('Not supported by component (PAPI_ECMP -4).'),
+   -5: CypapiEclost('Access to the counters was lost or interrupted (PAPI_ECLOST -5).'),
+   -6: CypapiEbug('Internal error, please send mail to the developers (PAPI_EBUG -6).'),
+   -7: CypapiEnoevnt('Hardware event does not exist (PAPI_ENOEVNT -7).'),
+   -8: CypapiEcnflct('Hardware event exists, but cannot be counted due to counter resource limitations (PAPI_ECNFLCT -8).'),
+   -9: CypapiEnotrun('No events or event sets are currently not counting (PAPI_ENOTRUN -9).'),
+   -10: CypapiEisrun('Event set is currently running (PAPI_EISRUN -10).'),
+   -11: CypapiEnoevst('No such event set available (PAPI_ENOEVST -11).'),
+   -12: CypapiEnotpreset('Event is not a valid preset (PAPI_ENOTPRESET -12).'),
+   -13: CypapiEnocntr('Hardware does not support performance counters (PAPI_ENOCNTR -13).'),
+   -14: CypapiEmisc('Unknown error code (PAPI_EMISC -14).'),
+   -15: CypapiEperm('You lack the necessary permissions (PAPI_EPERM -15).'),
+   -16: CypapiEnoinit('Cypapi has not been properly initialized with linked PAPI build (PAPI_ENOINIT -16).'),
+   -17: CypapiEnocmp('Component index is not set (PAPI_ENOCMP -17).'),
+   -18: CypapiEnosupp('Not supported (PAPI_ENOSUPP -18).'),
+   -19: CypapiEnoimpl('Not implemented (PAPI_ENOIMPL -19).'),
+   -20: CypapiEbuf('Buffer size exceeded (PAPI_EBUF -20).'),
+   -21: CypapiEinvalDom('Event set domain is not suppported for the operation (PAPI_EINVAL_DOM -21).'),
+   -22: CypapiEattr('Invalid or missing event attributes (PAPI_EATTR -22).'),
+   -23: CypapiEcount('Too many events or attributes (PAPI_ECOUNT -23).'),
+   -24: CypapiEcombo('Bad comination of features (PAPI_ECOMBO -24).'),
+   -25: CypapiEcmpDisabled('Component containing event is disabled (PAPI_ECMP_DISABLED -25).'),
+   -26: CypapiEdelayInit('Delayed initialization component (PAPI_EDELAY_INIT -26).'),
+   -27: CypapiEmulpass('Event exists, but cannot be counted due to multiple passes required by hardware (PAPI_EMULPASS -27).'),
+}

--- a/cypapi/cysdelib.pyx
+++ b/cypapi/cysdelib.pyx
@@ -1,8 +1,11 @@
 # cython: language_level=3str
-cimport posix.dlfcn as dlfcn
-cdef void *libhndl = dlfcn.dlopen('libpapi.so', dlfcn.RTLD_LAZY | dlfcn.RTLD_GLOBAL)
-
 import struct
+
+cimport posix.dlfcn as dlfcn
+
+from cypapi.sde_libh cimport *
+
+cdef void *libhndl = dlfcn.dlopen('libpapi.so', dlfcn.RTLD_LAZY | dlfcn.RTLD_GLOBAL)
 
 def pack_float_i64(float value):
     """A utility function to pack the bits of a float value into an int."""
@@ -11,8 +14,6 @@ def pack_float_i64(float value):
 def unpack_i64_float(long long int value):
     """A utility to unpack the bits of a float packed into a long long int."""
     return struct.unpack('d', struct.pack('q', value))[0]
-
-from sde_libh cimport *
 
 SDE_RO = PAPI_SDE_RO
 SDE_INSTANT = PAPI_SDE_INSTANT

--- a/cypapi/cysdelib.pyx
+++ b/cypapi/cysdelib.pyx
@@ -3,6 +3,7 @@ import struct
 
 cimport posix.dlfcn as dlfcn
 
+from cypapi.cypapi_exceptions import _exceptions_for_cypapi
 from cypapi.sde_libh cimport *
 
 cdef void *libhndl = dlfcn.dlopen('libpapi.so', dlfcn.RTLD_LAZY | dlfcn.RTLD_GLOBAL)
@@ -58,7 +59,7 @@ class SdeCounter:
         elif issubclass(cntr_type, float):
             _type = PAPI_SDE_double
         else:
-            raise Exception("Unsupported type of counter requested.")
+            raise ValueError('Invalid counter type requested.')
 
         self._counter = _cSdeCounter(cntr_mode, _type, init)
 
@@ -86,7 +87,7 @@ class SdeCounterCB:
         elif issubclass(cntr_type, float):
             _type = PAPI_SDE_double
         else:
-            raise Exception("SDE Error: Unsupported type of counter requested.")
+            raise ValueError('Invalid counter type requested.')
         
         self._counter = _cSdeCounter(cntr_mode, _type)
         self._pyfunc = func
@@ -100,15 +101,15 @@ cdef class _cSdeHandle:
         self.handle = papi_sde_init(<const char *> self.library_name_cstr)
 
         if self.handle is NULL:
-            raise Exception('SDE Error: Failed to initialize')
+            raise MemoryError('Failed to initialize SDE internal data-structures.')
 
     def __repr__(self):
         return f"{self.__class__.__name__}('{str(self.library_name_cstr, encoding='utf-8')}')"
 
     def shutdown(self):
-        cdef int sde_err = papi_sde_shutdown(self.handle)
-        if sde_err != SDE_OK:
-            raise Exception('SDE Error: papi_sde_shutdown failed.')
+        cdef int retval = papi_sde_shutdown(self.handle)
+        if retval != SDE_OK:
+            raise _exceptions_for_cypapi[retval]
 
     def register_counter(self, str event_name, _cSdeCounter counter):
         cdef void* pctr
@@ -118,44 +119,44 @@ cdef class _cSdeHandle:
         else:
             pctr = <void *> &counter.d_counter
 
-        cdef int sde_err = papi_sde_register_counter(
+        cdef int retval = papi_sde_register_counter(
             self.handle, <const char *> evt_name,
             counter.cntr_mode, counter.cntr_type, pctr
             )
-        if sde_err != SDE_OK:
-            raise Exception('SDE Error: papi_sde_register_counter failed.')
+        if retval != SDE_OK:
+            raise _exceptions_for_cypapi[retval]
 
     def register_counter_cb(self, str event_name, _cSdeCounter counter, py_func):
         cdef bytes evt_name = event_name.encode('utf-8')
-        cdef int sde_err = papi_sde_register_counter_cb(
+        cdef int retval = papi_sde_register_counter_cb(
             self.handle, <const char *> evt_name,
             counter.cntr_mode, counter.cntr_type,
             cb_caller, <void *> py_func
         )
-        if sde_err != SDE_OK:
-            raise Exception('SDE Error: papi_sde_register_counter_cb failed.')
+        if retval != SDE_OK:
+            raise _exceptions_for_cypapi[retval]
 
     def describe_counter(self, str event_name, str description):
         cdef bytes evt_name = event_name.encode('utf-8')
         cdef bytes descr = description.encode('utf-8')
-        cdef int sde_err = papi_sde_describe_counter(self.handle, <const char*> evt_name, <const char*> descr)
-        if sde_err != SDE_OK:
-            raise Exception('SDE Error: papi_sde_describe_counter failed')
+        cdef int retval = papi_sde_describe_counter(self.handle, <const char*> evt_name, <const char*> descr)
+        if retval != SDE_OK:
+            raise _exceptions_for_cypapi[retval]
 
     def unregister_counter(self, str event_name):
         cdef bytes evt_name = event_name.encode('utf-8')
-        cdef int sde_err = papi_sde_unregister_counter(self.handle, <const char *> evt_name)
-        if sde_err != SDE_OK:
-            raise Exception('SDE Error: papi_sde_unregister_counter failed')
+        cdef int retval = papi_sde_unregister_counter(self.handle, <const char *> evt_name)
+        if retval != SDE_OK:
+            raise _exceptions_for_cypapi[retval]
 
     def add_counter_to_group(self, str event_name, str group_name, int group_flag):
         cdef bytes evt_name = event_name.encode('utf-8')
         cdef bytes grp_name = group_name.encode('utf-8')
         if group_flag not in (PAPI_SDE_SUM, PAPI_SDE_MAX, PAPI_SDE_MIN):
-            raise Exception('SDE Error: Bad argument for group_flag')
-        cdef int sde_err = papi_sde_add_counter_to_group(self.handle, <const char*> evt_name, <const char *> grp_name, group_flag)
-        if sde_err != SDE_OK:
-            raise Exception('SDE_Error: papi_sde_add_counter_to_group failed')
+            raise ValueError('Invalid group flag provided.')
+        cdef int retval = papi_sde_add_counter_to_group(self.handle, <const char*> evt_name, <const char *> grp_name, group_flag)
+        if retval != SDE_OK:
+            raise _exceptions_for_cypapi[retval]
 
     def get_counter_handle(self, str event_name):
         cdef bytes evt_name = event_name.encode('utf-8')

--- a/cypapi/cytests/do_loops.py
+++ b/cypapi/cytests/do_loops.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 a, b = 0.5, 2.2
 
 def do_flops( n = 100 ):

--- a/cypapi/cytests/do_loops.py
+++ b/cypapi/cytests/do_loops.py
@@ -1,3 +1,5 @@
+# File contains helper functions for cytests
+
 a, b = 0.5, 2.2
 
 def do_flops( n = 100 ):

--- a/cypapi/cytests/realtime.py
+++ b/cypapi/cytests/realtime.py
@@ -1,42 +1,38 @@
 #!/usr/bin/env python3
 
-# import necessary functions
-from cypapi import *
+# imports necessary for script
+import cypapi as cyp
 from do_loops import do_flops
 
-perrno = PAPI_Error["PAPI_OK"]
+if __name__ == '__main__':
+    # initialize cyPAPI library
+    cyp.cyPAPI_library_init(cyp.PAPI_VER_CURRENT)
 
-# initialize cyPAPI library
-cyPAPI_library_init()
+    # check to make sure cyPAPI has been intialized
+    if cyp.cyPAPI_is_initialized() != 1:
+        raise ValueError("cyPAPI has not been initialized.\n")
 
-# check to make sure cyPAPI has been intialized
-if cyPAPI_is_initialized() != 1:
-    raise ValueError("cyPAPI has not been initialized.\n")
-
-# test real time cyPAPI functions
-try: 
-    # real time in clock cycles
-    rt_cc_start = cyPAPI_get_real_cyc()
-    do_flops()
-    rt_cc_stop = cyPAPI_get_real_cyc()
-    # real time in nanoseconds
-    rt_ns_start = cyPAPI_get_real_nsec()
-    do_flops()
-    rt_ns_stop = cyPAPI_get_real_nsec()
-    # real time in microseconds
-    rt_ms_start = cyPAPI_get_real_usec()
-    do_flops()
-    rt_ms_stop = cyPAPI_get_real_usec()
-# handle error
-except:
-    perrno = PAPI_Error["PAPI_EINVAL"]
-
-# output if real time cyPAPI functions succeeded
-if perrno == PAPI_Error["PAPI_OK"]:
-    print("Real time in clock cycles: ", rt_cc_stop - rt_cc_start)
-    print("Real time in nanoseconds: ", rt_ns_stop - rt_ns_start)
-    print("Real time in microseconds: ", rt_ms_stop - rt_ms_start)
-    print("\033[0;32mPASSED\033[0m");
-# output if real time cyPAPI functions failed
-else:
-    print("\033[0;31mFAILED\033[0m");
+    # test real time cyPAPI functions
+    try: 
+        # real time in clock cycles
+        rt_cc_start = cyp.cyPAPI_get_real_cyc()
+        do_flops()
+        rt_cc_stop = cyp.cyPAPI_get_real_cyc()
+        # real time in nanoseconds
+        rt_ns_start = cyp.cyPAPI_get_real_nsec()
+        do_flops()
+        rt_ns_stop = cyp.cyPAPI_get_real_nsec()
+        # real time in microseconds
+        rt_ms_start = cyp.cyPAPI_get_real_usec()
+        do_flops()
+        rt_ms_stop = cyp.cyPAPI_get_real_usec()
+    # collection of real time failed
+    except Exception:
+        print('\033[0;31mFAILED\033[0m')
+        raise
+    # collection of real time succeeded
+    else:
+        print('Real time in clock cycles: ', rt_cc_stop - rt_cc_start)
+        print('Real time in nanoseconds: ', rt_ns_stop - rt_ns_start)
+        print('Real time in microseconds: ', rt_ms_stop - rt_ms_start)
+        print('\033[0;32mPASSED\033[0m');

--- a/cypapi/cytests/torch_cuda.py
+++ b/cypapi/cytests/torch_cuda.py
@@ -1,68 +1,67 @@
 #!/usr/bin/env python3
 
-# import necessary libraries
-from cypapi import *
-
+# import necessary packages
 import torch
 
-perrno = PAPI_Error["PAPI_OK"]
+import cypapi as cyp
 
-# size of tensors
-m_rows = 1000
-n_cols = 1000
+if __name__ == '__main__':
+    # size of tensors
+    m_rows = 1000
+    n_cols = 1000
 
-# check to see if a device is available
-if torch.cuda.is_available():
-    unit = "cuda"
-else:
-    raise Exception("NVIDIA device needed.")
+    # check to see if a device is available
+    if torch.cuda.is_available():
+        unit = "cuda"
+    else:
+        raise ValueError("NVIDIA device needed.")
 
-try:
-    # initialize cyPAPI
-    cyPAPI_library_init()
+    try:
+        # initialize cyPAPI
+        cyp.cyPAPI_library_init(cyp.PAPI_VER_CURRENT)
 
-    # check to see if cyPAPI was successfully initialized
-    if cyPAPI_is_initialized() != 1:
-        raise ValueError( "cyPAPI has not been initialized.\n" )
+        # check to see if cyPAPI was successfully initialized
+        if cyp.cyPAPI_is_initialized() != 1:
+            raise ValueError( "cyPAPI has not been initialized.\n" )
 
-    # create  a cyPAPI EventSet 
-    cuda_eventset = CyPAPI_EventSet()
+        # create  a cyPAPI EventSet 
+        cuda_eventset = cyp.CypapiCreateEventset()
 
-    # get cuda component index
-    cidx = cyPAPI_get_component_index( unit )
+        # get cuda component index
+        cidx = cyp.cyPAPI_get_component_index(unit)
     
-    # collect cuda native event
-    cuda_cmp = CyPAPI_enum_component_events( cidx )
-    cuda_ntv_evt = cuda_cmp.next_event()
+        # collect cuda native event
+        cuda_cmp = cyp.CypapiEnumCmpEvent(cidx)
+        cuda_evt_code = cuda_cmp.next_event()
+        cuda_evt_name = cyp.cyPAPI_event_code_to_name(cuda_evt_code)
 
-    # add cuda native event to the EventSet
-    cuda_eventset.add_event(cuda_ntv_evt)
+        # add cuda native event to the EventSet
+        cuda_eventset.add_event(cuda_evt_code)
  
-    # start counting hardware events in the created EventSet
-    cuda_eventset.start()
+        # start counting hardware events in the created EventSet
+        cuda_eventset.start()
     
-    # create tensors for computation
-    matrix_A = torch.rand( m_rows, n_cols, device = unit )
-    matrix_B = torch.rand( m_rows, n_cols, device = unit )
-    # perform matrix multiplication
-    result_tensor = torch.mm( matrix_A, matrix_B )
+        # create tensors for computation
+        matrix_A = torch.rand( m_rows, n_cols, device = unit )
+        matrix_B = torch.rand( m_rows, n_cols, device = unit )
+        # perform matrix multiplication
+        result_tensor = torch.mm( matrix_A, matrix_B )
 
-    # transfer results to cpu
-    result_cpu = result_tensor.detach().cpu()
+        # transfer results to cpu
+        result_cpu = result_tensor.detach().cpu()
     
-    # stop counting hardware events in the created EventSet
-    hw_counts = cuda_eventset.stop()
-except:
-    perrno = PAPI_Error["PAPI_EINVAL"]
-
-# output if Cuda component has been successfully built
-if perrno == PAPI_Error["PAPI_OK"]:
-    # show number of available devices
-    print( "Number of available devices: ", torch.cuda.device_count() )
-    # show device name
-    print( "Device Name: ", torch.cuda.get_device_name( unit ) )
-    # counts for cuda native event 
-    print( f"Hardware Counts for {cyPAPI_event_code_to_name(cuda_ntv_evt)}:", hw_counts[0])
-    print("\033[0;32mPASSED\033[0m")
-else:
-    print("\033[0;31mFAILED\033[0m");
+        # stop counting hardware events in the created EventSet
+        hw_counts = cuda_eventset.stop()
+     # Cuda component was not successfully built
+    except Exception:
+        print('\033[0;31mFAILED\033[0m');
+        raise
+    # Cuda component has been successfully built
+    else:
+        # show number of available devices
+        print( "Number of available devices: ", torch.cuda.device_count() )
+        # show device name
+        print( "Device Name: ", torch.cuda.get_device_name( unit ) )
+        # counts for cuda native event 
+        print( f"Hardware Counts for {cuda_evt_name}:", hw_counts[0])
+        print("\033[0;32mPASSED\033[0m")

--- a/cypapi/cytests/torch_cuda.py
+++ b/cypapi/cytests/torch_cuda.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# import necessary packages
+# import necessary for script
 import torch
 
 import cypapi as cyp

--- a/cypapi/cytests/torch_cuda.py
+++ b/cypapi/cytests/torch_cuda.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# import necessary for script
+# imports necessary for script
 import torch
 
 import cypapi as cyp

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,4 @@ setup(
     packages=['cypapi'],
     ext_modules = cythonize([ext_papi,ext_sde,ext_papi_thr]),
     install_requires = ['numpy'],
-    include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, Extension
+from Cython.Build import cythonize
 import os
 import numpy
 
@@ -29,9 +30,9 @@ def configure_extension(ext: Extension, papi_path: str):
 if os.name == 'nt':
     raise NotImplementedError('cypapi does not currently support Windows OS')
 
-ext_papi = Extension('cypapi', sources=['cypapi/cypapi.pyx'], libraries=['papi'], include_dirs=[numpy.get_include()], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")])
-ext_sde = Extension('cysdelib', sources=['cypapi/cysdelib.pyx'], libraries=['papi', 'sde'], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")])
-ext_papi_thr = Extension('cypapithr', sources=['cypapi/threadsampler.pyx'], libraries=['papi'], include_dirs=[numpy.get_include()], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")])
+ext_papi = Extension('cypapi.cypapi', sources=['cypapi/cypapi.pyx'], libraries=['papi'], include_dirs=[numpy.get_include()], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")])
+ext_sde = Extension('cypapi.cysdelib', sources=['cypapi/cysdelib.pyx'], libraries=['papi', 'sde'], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")])
+ext_papi_thr = Extension('cypapi.cypapithr', sources=['cypapi/threadsampler.pyx'], libraries=['papi'], include_dirs=[numpy.get_include()], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")])
 
 papi_path = os.environ.get('PAPI_DIR')
 if not papi_path:
@@ -47,14 +48,9 @@ if papi_path:
     configure_extension(ext_papi_thr, papi_path)
 
 setup(
-    name = "cypapi",
-    version = '0.1',
-    description = 'Python interface for the PAPI performance monitoring library',
-    author = 'Anustuv Pal',
-    author_email = 'anustuv@gmail.com',
-    ext_modules = [ext_papi, ext_sde, ext_papi_thr],
+    name='cypapi',
+    packages=['cypapi'],
+    ext_modules = cythonize([ext_papi,ext_sde,ext_papi_thr]),
     install_requires = ['numpy'],
-    packages=[
-        'cypapi'
-    ]
+    include_package_data=True,
 )


### PR DESCRIPTION
This PR addresses adding custom Python exceptions to the cyPAPI package. This was done to follow the EAFP coding style that many Python developers prefer over the LBYL coding style. 

The cyPAPI custom exceptions are held within the `cypapi_exceptions.py` file. Each negative error code in PAPI has a cyPAPI custom exception counterpart. Note that `PAPI_OK` is represented by no exception being raised in cyPAPI. Lastly, to keep the code compact and accurately obtain the proper exception for the PAPI error code returned, a private dictionary `_exceptions_for_cypapi` was created to hold the custom exceptions. The dictionary is comprised of keys that represent the PAPI error codes and the values are the associated custom exception. See below for examples.

#### Example without Exception Handling from `cyPAPI_event_code_to_name`
Code:
```python
from cypapi import *

event_code = 0

name = cyPAPI_event_code_to_name(event_code)

print(name)
```
Output:
```
Traceback (most recent call last):
  File "/home/tburgess/jupyter-env/bin/cyPAPI/cypapi/test.py", line 5, in <module>
    name = cyPAPI_event_code_to_name(event_code)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "cypapi/cypapi.pyx", line 328, in cypapi.cyPAPI_event_code_to_name
    raise _exceptions_for_cypapi[retval]
cypapi_exceptions.CypapiEnoevnt: Hardware event does not exist.
```

#### Example with Exception Handling for `cyPAPI_event_code_to_name`
Code:
```python
from cypapi import *
from cypapi_exceptions import *

events = [0, PAPI_TOT_INS]
try:
    name = cyPAPI_event_code_to_name(events[0])
except CypapiEnoevnt as err:
    print(f'Exception message: {err}')
    try:
        name = cyPAPI_event_code_to_name(events[1])
    except CypapiEnoevnt:
        raise
    else:
        print(f'Event name for event code {events[1]}: {name}')
```
Output:
```
Exception message: Hardware event does not exist.
Event name for event code -2147483598: PAPI_TOT_INS
```


