### PR TITLE
Add Type Hints to cyPAPI

### DIFF
--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -1,6 +1,7 @@
 # cython: language_level=3str
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from dataclasses import dataclass, field, InitVar
+from collections.abc import Iterator
 from typing import Union
 
 import numpy as np
@@ -176,7 +177,7 @@ def cyPAPI_is_initialized() -> int:
 def cyPAPI_shutdown() -> None:
     PAPI_shutdown()
 
-def cyPAPI_strerror(error_code: int) ->str:
+def cyPAPI_strerror(error_code: int) -> str:
     cdef char *c_str = PAPI_strerror(error_code)
     if not c_str:
         raise ValueError('Failed to get error message.')

--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -1,27 +1,17 @@
 # cython: language_level=3str
-from dataclasses import dataclass, field, InitVar
-from typing import Dict, Iterable, List, Tuple, Union
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
-<<<<<<< HEAD
 from dataclasses import dataclass, field, InitVar
-
-import numpy as np
-
-=======
-import atexit
-import warnings
+from typing import Union
 
 import numpy as np
 import cython
->>>>>>> 37ab10c (Ading type hints to cyPAPI backwards compatible with Python >= 3.9.)
+
 cimport numpy as np
 cimport posix.dlfcn as dlfcn
 
 from cypapi.cypapi_exceptions import _exceptions_for_cypapi
 from cypapi.papih cimport *
 from cypapi.papiStdEventDefsh cimport *
-
-cdef void *libhndl = dlfcn.dlopen('libsde.so', dlfcn.RTLD_LAZY | dlfcn.RTLD_GLOBAL)
 
 cdef void *libhndl = dlfcn.dlopen('libsde.so', dlfcn.RTLD_LAZY | dlfcn.RTLD_GLOBAL)
 
@@ -183,107 +173,73 @@ def cyPAPI_library_init(version: int) -> int:
 def cyPAPI_is_initialized() -> int:
     return PAPI_is_initialized()
 
-<<<<<<< HEAD
-def cyPAPI_shutdown():
+def cyPAPI_shutdown() -> None:
     PAPI_shutdown()
 
-def cyPAPI_strerror(int error_code):
+def cyPAPI_strerror(error_code: int) ->str:
     cdef char *c_str = PAPI_strerror(error_code)
     if not c_str:
         raise ValueError('Failed to get error message.')
 
     return str(c_str, encoding='utf-8')
 
-def cyPAPI_num_components():
+def cyPAPI_num_components() -> int:
     cdef int retval = PAPI_num_components()
     if retval < 0:
         _exceptions_for_cypapi[retval]
 
     return retval 
 
-def cyPAPI_get_component_index(str name):
+def cyPAPI_get_component_index(name: str) -> int:
     cdef int retval = PAPI_get_component_index(name.encode('utf-8'))
     if retval < 0:
         raise _exceptions_for_cypapi[retval]
 
     return retval
 
-def cyPAPI_get_real_cyc():
+def cyPAPI_get_real_cyc() -> int:
     cdef long long retval = PAPI_get_real_cyc()
     if retval < 0:
         raise _exceptions_for_cypapi[retval]
 
     return retval
 
-def cyPAPI_get_real_nsec():
+def cyPAPI_get_real_nsec() -> int:
     cdef long long retval = PAPI_get_real_nsec()
     if retval < 0:
         raise _exceptions_for_cypapi[retval]
 
     return retval
 
-def cyPAPI_get_real_usec():
+def cyPAPI_get_real_usec() -> int:
     cdef long long retval = PAPI_get_real_usec()
     if retval < 0:
         raise _exceptions_for_cypapi[retval]
 
     return retval
 
-def cyPAPI_get_virt_cyc():
+def cyPAPI_get_virt_cyc() -> int:
     cdef long long retval = PAPI_get_virt_cyc()
     if retval < 0:
         raise _exceptions_for_cypapi[retval]
 
     return retval
 
-def cyPAPI_get_virt_nsec():
+def cyPAPI_get_virt_nsec() -> int:
     cdef long long retval = PAPI_get_virt_nsec()
     if retval < 0:
         raise _exceptions_for_cypapi[retval]
 
     return retval
 
-def cyPAPI_get_virt_usec():
+def cyPAPI_get_virt_usec() -> int:
     cdef long long retval = PAPI_get_virt_usec()
     if retval < 0:
         raise _exceptions_for_cypapi[retval]
 
     return retval
-=======
-@atexit.register
-def cyPAPI_shutdown() -> None:
-    PAPI_shutdown()
 
-def cyPAPI_strerror(error_code: int) -> str:
-    cdef char *c_str = PAPI_strerror(error_code)
-    return str(c_str, encoding='utf-8')
-
-def cyPAPI_num_components() -> int:
-    return PAPI_num_components()
-
-def cyPAPI_get_component_index(name: str) -> int:
-    return PAPI_get_component_index(name.encode('utf-8'))
-
-def cyPAPI_get_real_cyc() -> int:
-    return PAPI_get_real_cyc()
-
-def cyPAPI_get_real_nsec() -> int:
-    return PAPI_get_real_nsec()
-
-def cyPAPI_get_real_usec() -> int:
-    return PAPI_get_real_usec()
-
-def cyPAPI_get_virt_cyc() -> int:
-    return PAPI_get_virt_cyc()
-
-def cyPAPI_get_virt_nsec() -> int:
-    return PAPI_get_virt_nsec()
-
-def cyPAPI_get_virt_usec() -> int:
-    return PAPI_get_virt_usec()
->>>>>>> 37ab10c (Ading type hints to cyPAPI backwards compatible with Python >= 3.9.)
-
-def cyPAPI_enum_event(event_code: int, modifier: int) -> Tuple[Dict[str, str], int]:
+def cyPAPI_enum_event(event_code: int, modifier: int) -> tuple[dict[str, str], int]:
     """Enumerate PAPI preset or native events.
     
     Parameters
@@ -303,13 +259,8 @@ def cyPAPI_enum_event(event_code: int, modifier: int) -> Tuple[Dict[str, str], i
     int
         An event code.
     """
-<<<<<<< HEAD
     cdef int retval
-    cdef int evt_code = np.array(EventCode).astype(np.intc)
-=======
-    cdef int papi_errno = PAPI_OK
     cdef int evt_code = np.array(event_code).astype(np.intc)
->>>>>>> 37ab10c (Ading type hints to cyPAPI backwards compatible with Python >= 3.9.)
     cdef int mod = np.array(modifier).astype(np.intc)
     hexcode = 0xffffffff
     events = {}
@@ -346,19 +297,11 @@ def cyPAPI_enum_event(event_code: int, modifier: int) -> Tuple[Dict[str, str], i
 
     return events, evt_code
 
-<<<<<<< HEAD
-cdef void _PAPI_enum_cmp_event(int *EventCode, int modifier, int cidx) except *:
+cdef void _PAPI_enum_cmp_event(EventCode: cython.p_int, modifier: int, cidx: int) except *:
     cdef int retval = PAPI_enum_cmp_event(EventCode, modifier, cidx)
     if retval == PAPI_ENOCMP:
         raise _exceptions_for_cypapi[retval]
     if retval == PAPI_ENOEVNT or retval == PAPI_EINVAL:
-=======
-cdef void _PAPI_enum_cmp_event(EventCode: cython.p_int, modifier: int, cidx: int) except *:
-    cdef int papi_errno = PAPI_enum_cmp_event(EventCode, modifier, cidx)
-    if papi_errno == PAPI_ENOCMP:
-        raise Exception(f'PAPI Error {papi_errno}: PAPI_enum_cmp_event failed.')
-    if papi_errno == PAPI_ENOEVNT or papi_errno == PAPI_EINVAL:
->>>>>>> 37ab10c (Ading type hints to cyPAPI backwards compatible with Python >= 3.9.)
         raise StopIteration
 
 cdef class CypapiEnumCmpEvent:
@@ -385,41 +328,25 @@ cdef class CypapiEnumCmpEvent:
     def __next__(self) -> int:
         return self.next_event()
 
-<<<<<<< HEAD
-def cyPAPI_query_event(event_code):
+def cyPAPI_query_event(event_code: int) -> int:
     cdef int retval
     cdef int evt_code = np.array(event_code).astype(np.intc)
     retval = PAPI_query_event(evt_code)
-=======
-def cyPAPI_query_event(event_code: int) -> int:
-    cdef int papi_errno, evt_code = np.array(event_code).astype(np.intc)
-    papi_errno = PAPI_query_event(evt_code)
->>>>>>> 37ab10c (Ading type hints to cyPAPI backwards compatible with Python >= 3.9.)
 
     return retval
 
-<<<<<<< HEAD
-def cyPAPI_query_named_event(event_name):
-    cdef int retval
-=======
 def cyPAPI_query_named_event(event_name: str) -> int:
-    cdef int papi_errno
->>>>>>> 37ab10c (Ading type hints to cyPAPI backwards compatible with Python >= 3.9.)
+    cdef int retval
     cdef bytes evt_name = event_name.encode('utf8')
     retval = PAPI_query_named_event(evt_name)
 
     return retval
 
-<<<<<<< HEAD
-def cyPAPI_num_cmp_hwctrs(int cidx):
+def cyPAPI_num_cmp_hwctrs(cidx: int) -> int:
     cdef int retval = PAPI_num_cmp_hwctrs(cidx)
     if retval < 0:
         raise _exceptions_for_cypapi[retval]
     return retval
-=======
-def cyPAPI_num_cmp_hwctrs(cidx: int) -> int:
-    return PAPI_num_cmp_hwctrs(cidx)
->>>>>>> 37ab10c (Ading type hints to cyPAPI backwards compatible with Python >= 3.9.)
 
 def cyPAPI_event_code_to_name(event_code: int) -> str:
     # convert Python integer to Numpy value, which follows C overflow logic
@@ -733,57 +660,31 @@ cdef class CypapiCreateEventset:
     def __str__(self) -> str:
         return f'{self.event_set}'
 
-<<<<<<< HEAD
-    def cleanup_eventset(self):
+    def cleanup_eventset(self) -> None:
         cdef int retval = PAPI_cleanup_eventset(self.event_set)
         if retval != PAPI_OK:
             raise _exceptions_for_cypapi[retval]
 
-    def destroy_eventset(self):
+    def destroy_eventset(self) -> None:
         cdef int retval = PAPI_destroy_eventset(&self.event_set)
         if retval != PAPI_OK:
             raise _exceptions_for_cypapi[retval]
 
-    def num_events(self):
+    def num_events(self) -> int:
         cdef int retval = PAPI_num_events(self.event_set)
         if retval < 0:
             raise _exceptions_for_cypapi[retval]
         return retval
 
-    def assign_eventset_component(self, int cidx):
+    def assign_eventset_component(self, cidx: int) -> None:
         cdef int retval = PAPI_assign_eventset_component(self.event_set, cidx)
         if retval != PAPI_OK:
             raise _exceptions_for_cypapi[retval]
 
-    def reset(self):
+    def reset(self) -> None:
         cdef int retval = PAPI_reset(self.event_set)
         if retval != PAPI_OK:
             raise _exceptions_for_cypapi[retval]
-=======
-    def cleanup_eventset(self) -> None:
-        cdef papi_errno = PAPI_cleanup_eventset(self.event_set)
-        if papi_errno != PAPI_OK:
-            raise Exception(f'PAPI_Error {papi_errno}: Failed to cleanup eventset.')
-
-    def destroy_eventset(self) -> None:
-        cdef papi_errno
-        papi_errno = PAPI_destroy_eventset(&self.event_set)
-        if papi_errno != PAPI_OK:
-            raise Exception(f'PAPI_Errno {papi_errno}: Failed to destroy eventset.')
-
-    def num_events(self) -> int:
-        return PAPI_num_events(self.event_set)
-
-    def assign_eventset_component(self, cidx: int) -> None:
-        cdef int papi_errno = PAPI_assign_eventset_component(self.event_set, cidx)
-        if papi_errno != PAPI_OK:
-            raise Exception(f'PAPI Error {papi_errno}: Failed to assign component to eventset {self.event_set}')
-
-    def reset(self) -> None:
-        cdef int papi_errno = PAPI_reset(self.event_set)
-        if papi_errno != PAPI_OK:
-            raise Exception(f'PAPI Error {papi_errno}: Failed to reset eventset {self.event_set}')
->>>>>>> 37ab10c (Ading type hints to cyPAPI backwards compatible with Python >= 3.9.)
 
     def add_event(self, event_code: int) -> None:
         # convert Python integer to Numpy value, which follows C overflow logic
@@ -792,19 +693,18 @@ cdef class CypapiCreateEventset:
         if retval != PAPI_OK:
             raise _exceptions_for_cypapi[retval]
 
-<<<<<<< HEAD
-    def add_named_event(self, str name):
-        cdef bytes c_name = name.encode('utf-8')
+    def add_named_event(self, event_name: str) -> None:
+        cdef bytes c_name = event_name.encode('utf-8')
         cdef int retval = PAPI_add_named_event(self.event_set, c_name)
         if retval != PAPI_OK:
             raise _exceptions_for_cypapi[retval]
 
-    def start(self):
+    def start(self) -> None:
         cdef int retval = PAPI_start(self.event_set)
         if retval != PAPI_OK:
             raise _exceptions_for_cypapi[retval]
 
-    def stop(self):
+    def stop(self) -> list[int]:
         cdef int retval
          # memory allocation for array to be passed to PAPI function
         cdef long long *counter_vals = <long long *> PyMem_Malloc(
@@ -825,7 +725,7 @@ cdef class CypapiCreateEventset:
         finally:
             PyMem_Free(counter_vals)
 
-    def read(self):
+    def read(self) -> list[int]:
         cdef int retval
         # memory allocation for array to be passed to PAPI function
         cdef long long *counter_vals = <long long *> PyMem_Malloc(
@@ -846,7 +746,7 @@ cdef class CypapiCreateEventset:
         finally:
             PyMem_Free(counter_vals)
 
-    def read_ts(self):
+    def read_ts(self) -> tuple[list[int], int]:
         cdef int retval
         cdef long long cycles = -1
         # memory allocation for array to be passed to PAPI function
@@ -869,61 +769,8 @@ cdef class CypapiCreateEventset:
         finally:
             PyMem_Free(counter_vals)
 
-    def accum(self, list values):
+    def accum(self, values: list[int]) -> list[int]:
         cdef int retval
-=======
-    def add_named_event(self, event_name: str) -> None:
-        cdef bytes c_name = event_name.encode('utf-8')
-        cdef int papi_errno = PAPI_add_named_event(self.event_set, c_name)
-        if papi_errno != PAPI_OK:
-            raise Exception(f'PAPI Error {papi_errno}: Failed to add event {event_name} to eventset {self.event_set}')
-
-    def start(self) -> None:
-        cdef int papi_errno = PAPI_start(self.event_set)
-        if papi_errno != PAPI_OK:
-            raise Exception(f'PAPI Error {papi_errno}: PAPI_start faled')
-
-    def stop(self) -> List[int]:
-        cdef int num_events = self.num_events()
-        cdef long long *values = <long long *> PyMem_Malloc(num_events * sizeof(long long))
-        if not values:
-            raise MemoryError('Failed to allocate long long array')
-        cdef int papi_errno = PAPI_stop(self.event_set, values)
-        if papi_errno != PAPI_OK:
-            PyMem_Free(values)
-            raise Exception(f'PAPI Error {papi_errno}: PAPI_stop faled')
-        result = [values[i] for i in range(num_events)]
-        PyMem_Free(values)
-        return result
-
-    def read(self) -> List[int]:
-        cdef int num_events = self.num_events()
-        cdef long long *values = <long long *> PyMem_Malloc(num_events * sizeof(long long))
-        if not values:
-            raise MemoryError('Failed to allocate long long array')
-        cdef int papi_errno = PAPI_read(self.event_set, values)
-        if papi_errno != PAPI_OK:
-            raise Exception(f'PAPI Error {papi_errno}: PAPI_read failed')
-        result = [values[i] for i in range(num_events)]
-        PyMem_Free(values)
-        return result
-
-    def read_ts(self) -> Tuple[List[int], int]:
-        cdef int num_events = self.num_events()
-        cdef long long *values = <long long *> PyMem_Malloc(num_events * sizeof(long long))
-        if not values:
-            raise Exception(f'Failed to allocate array')
-        cdef long long cyc = -1
-        cdef int papi_errno = PAPI_read_ts(self.event_set, values, &cyc)
-        if papi_errno != PAPI_OK:
-            raise Exception(f'PAPI Error {papi_errno}: PAPI_read_ts failed')
-        result = [values[i] for i in range(num_events)]
-        PyMem_Free(values)
-        return result, cyc
-
-    def accum(self, values: List[int]) -> List[int]:
-        cdef int papi_errno
->>>>>>> 37ab10c (Ading type hints to cyPAPI backwards compatible with Python >= 3.9.)
         # the list values must be initialized for accum
         if self.num_events() != len(values):
             raise ValueError('Provided list must have the same length as the'
@@ -949,13 +796,8 @@ cdef class CypapiCreateEventset:
         finally:
             PyMem_Free(counter_vals)
 
-<<<<<<< HEAD
-    def list_events(self, probe = False):
+    def list_events(self, probe: bool = False) -> Union[list[int], int]:
         cdef int *evts, retval, num_events = self.num_events()
-=======
-    def list_events(self, probe: bool = False) -> Union[List[int], int]:
-        cdef int *evts, papi_errno, num_events = self.num_events()
->>>>>>> 37ab10c (Ading type hints to cyPAPI backwards compatible with Python >= 3.9.)
         # does not probe EventSet
         if not probe:
             evts = <int *> PyMem_Malloc(num_events * sizeof(int))
@@ -983,12 +825,8 @@ cdef class CypapiCreateEventset:
             raise _exceptions_for_cypapi[retval]
         return val
 
-<<<<<<< HEAD
-    def write(self, list values):
+    def write(self, values: list[int]) -> None:
         cdef int retval
-=======
-    def write(self, values: List[int]) -> None:
->>>>>>> 37ab10c (Ading type hints to cyPAPI backwards compatible with Python >= 3.9.)
         cdef int num_events = self.num_events()
         if len(values) > num_events:
             raise ValueError('Provided list must have the same length as the'
@@ -1004,18 +842,8 @@ cdef class CypapiCreateEventset:
         if retval != PAPI_OK:
             raise _exceptions_for_cypapi[retval]
 
-<<<<<<< HEAD
-    def get_eventset_component(self):
+    def get_eventset_component(self) -> int:
         cdef int retval = PAPI_get_eventset_component(self.event_set)
         if retval < 0:
             raise _exceptions_for_cypapi[retval]
         return retval
-=======
-    def get_eventset_component(self) -> int:
-        cdef int cid = PAPI_get_eventset_component(self.event_set)
-        if cid < 0:
-            raise Exception(f'PAPI Error {cid}: Failed to get eventset component index')
-        return cid
-
-del atexit, warnings
->>>>>>> 37ab10c (Ading type hints to cyPAPI backwards compatible with Python >= 3.9.)


### PR DESCRIPTION
This PR adds type hinting to cyPAPI functions and classes. The goal is the following:

1. Improve documentation of cyPAPI codebase
2. Help with development by IDE's being able to catch mismatched types

Type hints were added based off the following Python [documentation](https://docs.python.org/pl/3.6/library/typing.html) to support Python 3.6. 

As a note, I have gone with the implementation of `from typing import Dict, List, Tuple, Union`. The reason for this is to make the type hinting backwards compatible with later versions of Python. However, this implementation could be removed in later Python releases (at earliest October 2025 when Python 3.9 hits end of life); therefore, it is something to keep an eye on. As of now, `from typing import Dict, List, Tuple, Union` still works with later releases of Python such as 3.11.  See [PEP 585](https://peps.python.org/pep-0585/) for more details.