### PR TITLE
Restrucure code for list_events, stop, read_ts, and read to use try, finally blocks

### DIFF
--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -699,6 +699,7 @@ cdef class CypapiCreateEventset:
         # handle PAPI function call
         papi_errno = PAPI_read(self.event_set, counter_vals)
         if papi_errno != PAPI_OK:
+            PyMem_Free(counter_vals)
             raise Exception(f'PAPI Error {papi_errno}: PAPI_read failed')
         
         # try to convert array of counter values to list to be returned
@@ -720,6 +721,7 @@ cdef class CypapiCreateEventset:
         # handle PAPI function call
         papi_errno = PAPI_read_ts(self.event_set, counter_vals, &cycles)
         if papi_errno != PAPI_OK:
+            PyMem_Free(counter_vals)
             raise Exception(f'PAPI Error {papi_errno}: PAPI_read_ts failed')
         
         # try to convert array of counter values to list to be returned

--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -678,7 +678,7 @@ cdef class CypapiCreateEventset:
         # handle PAPI function call
         papi_errno = PAPI_stop(self.event_set, counter_vals)
         if papi_errno != PAPI_OK:
-            PyMem_Free(values)
+            PyMem_Free(counter_vals)
             raise Exception(f'PAPI Error {papi_errno}: PAPI_stop faled')
 
         # try to convert array of counter values to list to be returned
@@ -786,6 +786,7 @@ cdef class CypapiCreateEventset:
         return val
 
     def write(self, list values):
+        cdef int papi_errno
         cdef int num_events = self.num_events()
         if len(values) > num_events:
             raise Exception('Too many values to write')
@@ -795,7 +796,7 @@ cdef class CypapiCreateEventset:
         cdef int i
         for i in range(len(values)):
             vals[i] = values[i]
-        cdef papi_errno = PAPI_write(self.event_set, vals)
+        papi_errno = PAPI_write(self.event_set, vals)
         PyMem_Free(vals)
         if papi_errno != PAPI_OK:
             raise Exception(f'PAPI Error {papi_errno}: PAPI_write failed')


### PR DESCRIPTION
This PR addresses restructuring code for the following four methods in the `CypapiCreateEventset` class:

- `.list_events()`
- `.stop()`
- `.read_ts()`
- `.read()`

All four of these methods utilize list comprehension to convert the memory allocated C array to a Python list which can subsequently be returned to a user. This restructuring sees the use of a `try` and `finally` block to make sure that the conversion is successful.

Reasons for this are:

- Even if the conversion fails in the `try` block, the `finally` block will still run. This means that memory allocation can still be freed after an exception occurred.
- Utilizing this code structure is more Pythonic, and even is showcased in Cython's own documentation. See the following [link](https://cython.readthedocs.io/en/latest/src/tutorial/memory_allocation.html).