### PR TITLE
list_events method: Update order of declarations such that compilation warning of non-trivial type declarations does not occur.

### DIFF
--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -798,7 +798,8 @@ cdef class CypapiCreateEventset:
             PyMem_Free(counter_vals)
 
     def list_events(self, probe: bool = False) -> Union[list[int], int]:
-        cdef int *evts, retval, num_events = self.num_events()
+        cdef int *evts
+        cdef int retval, num_events = self.num_events()
         # does not probe EventSet
         if not probe:
             evts = <int *> PyMem_Malloc(num_events * sizeof(int))


### PR DESCRIPTION
Currently in the master branch if you build cyPAPI the following warning occurs during compilation:
```
warning: cypapi/cypapi.pyx:801:17: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
```
This is due to the following line of code in the method `list_events`:
```python
cdef int *evts, retval, num_events = self.num_events()
```

This PR resolves this warning, by restructuring the declarations in `list_events` to be:
```
cdef int *evts
cdef int retval, num_events = self.num_events()
```