### PR TITLE
CypapiCreateEventset: Add remove_event and remove_named_event methods

### DIFF
--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -706,6 +706,12 @@ cdef class CypapiCreateEventset:
         if retval != PAPI_OK:
             raise _exceptions_for_cypapi[retval]
 
+    def remove_named_event(self, event_name: str) -> None:
+        cdef bytes c_string_event_name = event_name.encode('utf-8')
+        cdef int retval = PAPI_remove_named_event(self.event_set, c_string_event_name)
+        if retval != PAPI_OK:
+            raise _exceptions_for_cypapi[retval]
+
     def start(self) -> None:
         cdef int retval = PAPI_start(self.event_set)
         if retval != PAPI_OK:

--- a/cypapi/papih.pxd
+++ b/cypapi/papih.pxd
@@ -57,6 +57,7 @@ cdef extern from 'papi.h':
     int PAPI_add_named_event(int EventSet, const char *EventName)
     ## Removing events
     int PAPI_remove_event(int EventSet, int EventCode)
+    int PAPI_remove_named_event(int EventSet, const char *EventName)
     ## Counting hardware events               
     int PAPI_start(int EventSet)                                                
     int PAPI_stop(int EventSet, long long * values)                             


### PR DESCRIPTION
This PR adds support for the method `remove_event` in the class `CypapiCreateEventset`. 

# Testing for this PR
Testing was done on a machine with an Intel Xeon Gold 6140 with 1 * A100 using Cuda Toolkit 12.6.0.

The Python script used is as follows:
```python
#!/usr/bin/env python3

import cypapi as cyp 

if __name__ == '__main__':
    try:
        # Initialize cyPAPI
        cyp.cyPAPI_library_init(cyp.PAPI_VER_CURRENT)

        # Check to see if cyPAPI was successfully initialized
        if cyp.cyPAPI_is_initialized() != 1:
            raise ValueError( "cyPAPI has not been initialized.\n" )

        # Create a cyPAPI EventSet 
        eventSet = cyp.CypapiCreateEventset()

        list_of_event_codes = [cyp.PAPI_TOT_INS]
        components = ["perf_event"]
        for component in components:
            # Get a components index 
            cidx = cyp.cyPAPI_get_component_index(component)

            # Get an event code and append it to the list
            enumCmp = cyp.CypapiEnumCmpEvent(cidx)
            eventCode = enumCmp.next_event()
            list_of_event_codes.append(eventCode)

        for code in list_of_event_codes:
            eventSet.add_event(code)

        print(f"Number of events after add_event for {component}: {eventSet.num_events()}")

        for code in list_of_event_codes:
            eventSet.remove_event(code)

        print(f"Number of events after remove_event for {component}: {eventSet.num_events()}")
    except Exception as e:
        raise e
```

Output:
```
(my_virtual) [ICL:methane cytests]$ python3 test_remove_event.py 
Number of events after add_event for perf_event: 2
Number of events after remove_event for perf_event: 0
```

Changing `.remove_event` to `.remove_named_event` holds the same results. 

Along with the above script, no issues were encountered during compilation.

