### PR TITLE
Resolve cuda component preset compilation error when linking with a PAPI that does not have cuda compiled in

### DIFF
--- a/cypapi/cypapi.pyx
+++ b/cypapi/cypapi.pyx
@@ -13,7 +13,8 @@ cimport posix.dlfcn as dlfcn
 from cypapi.cypapi_exceptions import _exceptions_for_cypapi
 from cypapi.papi cimport *
 from cypapi.papiStdEventDefs cimport *
-from cypapi.papiCudaStdEventDefs cimport *
+if CUDA_COMPILED_IN:
+    from cypapi.papiCudaStdEventDefs cimport *
 
 # PAPI versioning
 PAPI_VER_CURRENT = _PAPI_VER_CURRENT
@@ -136,12 +137,13 @@ PAPI_VEC_DP = _PAPI_VEC_DP
 PAPI_REF_CYC = _PAPI_REF_CYC
 
 # importing Cuda GPU preset defines to be used in cyPAPI
-PAPI_CUDA_FP16_FMA = _PAPI_CUDA_FP16_FMA
-PAPI_CUDA_BF16_FMA = _PAPI_CUDA_BF16_FMA
-PAPI_CUDA_FP32_FMA = _PAPI_CUDA_FP32_FMA
-PAPI_CUDA_FP64_FMA = _PAPI_CUDA_FP64_FMA
-PAPI_CUDA_FP_FMA   = _PAPI_CUDA_FP_FMA
-PAPI_CUDA_FP8_OPS  = _PAPI_CUDA_FP8_OPS
+if CUDA_COMPILED_IN:
+    PAPI_CUDA_FP16_FMA = _PAPI_CUDA_FP16_FMA
+    PAPI_CUDA_BF16_FMA = _PAPI_CUDA_BF16_FMA
+    PAPI_CUDA_FP32_FMA = _PAPI_CUDA_FP32_FMA
+    PAPI_CUDA_FP64_FMA = _PAPI_CUDA_FP64_FMA
+    PAPI_CUDA_FP_FMA   = _PAPI_CUDA_FP_FMA
+    PAPI_CUDA_FP8_OPS  = _PAPI_CUDA_FP8_OPS
 
 # importing native mask and preset mask
 PAPI_PRESET_MASK = _PAPI_PRESET_MASK


### PR DESCRIPTION
## Issue:
Currently in the main branch, if a user links a PAPI build that does not have the `cuda` component compiled in the following compilation error will occur:
```
 cypapi/cypapi.c:1173:10: fatal error: papi_cuda_std_event_defs.h: No such file or directory
   1173 | #include "papi_cuda_std_event_defs.h"
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
  compilation terminated.
  error: command '/usr/bin/gcc' failed with exit code 1
  error: subprocess-exited-with-error
```

This is due to the file `papi_cuda_std_event_defs.h` only being placed in a papi build directory if a user has compiled in the `cuda` component. This behavior differs from the CPU presets header which is always placed inside the papi build directory. 

This PR resolves this issue by adding conditional compilation checks using `compile_time_env`. This arg is not well documented, but from what I gathered from other Cython users as well as examples, it allows you to set variables that can be used and checked against during compilation. [PR #81](https://github.com/cython/cython/pull/81) originally added this in Cython.

I went with Python `if` statements over `IF` statements from Cython as the latter would output a deprecated message.

## Testing 

### Testing On Methane at ICL (Intel Xeon Gold 6140 and 1 * A100):

Linked PAPI did not have the `cuda` component compiled in: 
    - cyPAPI compilation - ✅ 
    - all_presets.py and realtime.py - ✅ 
    - Unable to use cuda component presets - ✅

Linked PAPI did have the `cuda` component compiled in:
    - cyPAPI compilation - ✅ 
    - all_presets.py, realtime.py, and torch_cuda.py - ✅ 
    - Cuda presets can be used - ✅ 

### Testing on Illyad at Oregon (AMD EPYC 7402 and 1 * H100):

Linked PAPI did not have the `cuda` component compiled in: 
    - cyPAPI compilation - ✅ 
    - all_presets.py and realtime.py - ✅ 
    - Unable to use cuda component presets - ✅ 
 
Linked PAPI did have the `cuda` component compiled in:
    - cyPAPI compilation - ✅ 
    - all_presets.py, realtime.py, and torch_cuda.py (modified to use cuda:::dram__bytes:stat=max:device=0 as CTC events cannot be profiled) - ✅ 
    - Cuda presets can be used - ✅ 
